### PR TITLE
Write apigentools.info after generation

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -158,7 +158,6 @@ class GenerateCommand(Command):
         # API versions)
         for language in languages:
             language_config = self.config.get_language_config(language)
-            self.write_dot_apigentools_info(language)
             for version in language_config.spec_versions:
                 log.info("Generation in %s, spec version %s", language, version)
                 language_oapi_config_path = os.path.join(
@@ -200,5 +199,9 @@ class GenerateCommand(Command):
                     language,
                     self.args.downstream_templates_dir,
                 )
+
+            # Write the apigentools.info file once per language
+            # after each nested folder has been created
+            self.write_dot_apigentools_info(language)
 
         return 0


### PR DESCRIPTION
Moves the writing of the .apigentools_info file to be done after the generation command is complete for that language. 

Doing so before (if there is no generated folder yet) results in the following exception due to the folders not being created yet:

```
  File "/Users/Library/Python/3.7/lib/python/site-packages/apigentools/commands/generate.py", line 141, in write_dot_apigentools_info
    with open(outfile, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'generated/datadog-api-client-go/.apigentools-info'
```

Since this file isn't used during the generation process, moving it after safely can rely on these folders being present. 