### PR TITLE
Make push command a clear WIP not ready to be used

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -215,7 +215,7 @@ def get_cli_parser():
 
     push_parser = sp.add_parser(
         "push",
-        help="Push the generated source code into each git repository specified in the config",
+        help="[WIP Not Yet Available] Push the generated source code into each git repository specified in the config",
     )
     push_parser.add_argument(
         "--use_https",

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -18,6 +18,9 @@ REPO_HTTPS_URL = 'https://github.com/{}/{}.git'
 class PushCommand(Command):
 
     def run(self):
+        log.error("The push command is a work in progress and isn't currently available")
+        return 1
+
         created_branches = {}
         cmd_result = 0
 


### PR DESCRIPTION
### What does this PR do?

Make the `push` command unavailable for people to use. Logs an error and returns a message that its not ready yet. 

### Motivation

More work needs to be done to finish up this command and make it work properly. 

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
