### PR TITLE
Add codegen_version to .apigentools-info

### DIFF
--- a/docs/reproducible.md
+++ b/docs/reproducible.md
@@ -7,6 +7,7 @@ One of the core concepts of apigentools is reproducible code generation. In orde
         {
             "additional_stamps": [],
             "apigentools_version": "0.1.0.dev1",
+            "codegen_version": "4.0.1",
             "image": "apigentools:local",
             "info_version": "1"
             "spec_repo_commit": "36cefa8",
@@ -15,8 +16,9 @@ One of the core concepts of apigentools is reproducible code generation. In orde
     * `additional_stamps` is a list of strings given through `--additional-stamp` argument (empty if none are given)
         * As an example, you might want to use additional stamps when using a post-processing tool (as a `post` command in [config/config.json](spec_repo.md#configconfigjson)) on the generated code, which does actual changes to the code. E.g. if you decided to use [black](https://black.readthedocs.io/en/stable/) on generated Python code, you could specify `--additional-stamp black=1.2.3` to record its version.
     * `apigentools_version` is a version of apigentools used to generate code
+    * `codegen_version` is a version of the used code generation tool (openapi-generator)
     * `image` is a name and tag of the Docker image in which code generation happened (`null` if outside of Docker image)
     * `info_version` is a version of format of this document
     * `spec_repo_commit` is a commit of the Spec Repository (`null` if it's not a git repository)
 
-* All the templates rendered with openapi-generator get an additional key in context, `apigentoolsStamp`, which contains the same set of information as `.apigentools-info` in a condensed form, for example: `Generated with: apigentools version 0.1.0.dev1 (image: apigentools:local); spec repo commit 36cefa8`. You can use this in your template patches and/or downstream templates as `{{apigentoolsStamp}}` tag if you wish.
+* All the templates rendered with openapi-generator get an additional key in context, `apigentoolsStamp`, which contains the same set of information as `.apigentools-info` in a condensed form, for example: `Generated with: apigentools version 0.1.0.dev1 (image: apigentools:local); spec repo commit 36cefa8; codegen version 4.0.1`. You can use this in your template patches and/or downstream templates as `{{apigentoolsStamp}}` tag if you wish.


### PR DESCRIPTION
### What does this PR do?

Adds version of the used `codegen_exec` to `.apigentools-info`.

### Motivation

This makes sure we can better manage reproducibility.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
