### PR TITLE
Tag builds with ':git-abcd123', use that tag in container-apigentools

### DIFF
--- a/container-apigentools
+++ b/container-apigentools
@@ -36,7 +36,9 @@ fi
 # e.g. apigentools/apigentools:0.1.0 or apigentools/apigentools:git-1234abc already
 IMAGE=$1
 if echo "$1" | grep -q ":latest$"; then
-    IMAGE_WITH_GIT_TAG=`docker inspect $1 -f "{{range .RepoTags}}{{println .}}{{end}}" | grep ":git-.......$"`
+    # since inspect wouldn't pull the image (unlike run), we make sure the inspected image is present explicitly
+    docker image inspect $1 > /dev/null 2>&1 || docker image pull $1;
+    IMAGE_WITH_GIT_TAG=`docker image inspect $1 -f "{{range .RepoTags}}{{println .}}{{end}}" | grep ":git-.......$"`
     if [[ "$?" -eq "0" ]]; then
         IMAGE=$IMAGE_WITH_GIT_TAG
     fi

--- a/container-apigentools
+++ b/container-apigentools
@@ -30,7 +30,18 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     exit 0
 fi
 
-IMAGE="$1"
+# if the user passed in something like apigentools/apigentools:latest, let's try using
+# a tag of that image that has for of "git-1234abc" - this will get saved to .apigentools-info
+# and is necessary for reproducibility and trackability - otherwise the user passed in
+# e.g. apigentools/apigentools:0.1.0 or apigentools/apigentools:git-1234abc already
+IMAGE=$1
+if echo "$1" | grep -q ":latest$"; then
+    IMAGE_WITH_GIT_TAG=`docker inspect $1 -f "{{range .RepoTags}}{{println .}}{{end}}" | grep ":git-.......$"`
+    if [[ "$?" -eq "0" ]]; then
+        IMAGE=$IMAGE_WITH_GIT_TAG
+    fi
+fi
+
 shift
 
 SPEC_REPO_VOLUME="$(pwd)"

--- a/container-apigentools
+++ b/container-apigentools
@@ -31,7 +31,7 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
 fi
 
 # if the user passed in something like apigentools/apigentools:latest, let's try using
-# a tag of that image that has for of "git-1234abc" - this will get saved to .apigentools-info
+# a tag of that image that has the format of "git-1234abc" - this will get saved to .apigentools-info
 # and is necessary for reproducibility and trackability - otherwise the user passed in
 # e.g. apigentools/apigentools:0.1.0 or apigentools/apigentools:git-1234abc already
 IMAGE=$1

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Tag the image both with the $IMAGE_NAME given and with $SOURCE_COMMIT
+docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME -t $DOCKER_REPO:git-${SOURCE_COMMIT:0:7} .


### PR DESCRIPTION
### What does this PR do?

* Makes images built at dockerhub automatically be tagged with `:git-abcd123` (in addition to `latest` or `X.Y.X`).
* If user passes `apigentools/apigentools:latest` to the `container-apigentools`, it tries to use this tag so that it's present in `.apigentools-info` in the generated source code (this ensures that we have trackability/reproducibility).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
