### PR TITLE
mkdocs requires 4 spaces to indent nested lists

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,19 +7,18 @@ This page summarizes the typical workflow that you would use when doing changes 
 Generally, the workflow steps are:
 
 * First time setup:
-  1. Get set up
-  2. Create "Spec Repo"
-
+    1. Get set up
+    2. Create "Spec Repo"
 * Repeated:
-  1. (If necessary) Modify the OpenAPI spec sections
-  2. (If necessary) Modify apigentools configuration
-  3. Validate specs (locally or using Docker)
-  4. (If necessary) Add template patches
-  5. (If necessary) Add downstream templates
-  6. (If necessary) Prepare templates (locally or using Docker)
-  7. Generate client code (locally or using Docker)
-  8. Run tests
-  9. (WIP) Push code
+    1. (If necessary) Modify the OpenAPI spec sections
+    2. (If necessary) Modify apigentools configuration
+    3. Validate specs (locally or using Docker)
+    4. (If necessary) Add template patches
+    5. (If necessary) Add downstream templates
+    6. (If necessary) Prepare templates (locally or using Docker)
+    7. Generate client code (locally or using Docker)
+    8. Run tests
+    9. (WIP) Push code
 
 The following sections explain the individual steps.
 


### PR DESCRIPTION
### What does this PR do?

mkdocs requires nested lists to be indented by 4 spaces, so this PR corrects our docs to use that.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
