### PR TITLE
Fix typo in generate command which makes it exit after first language

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -260,7 +260,7 @@ class GenerateCommand(Command):
             # after each nested folder has been created
             self.write_dot_apigentools_info(language)
 
-            return 0
+        return 0
 
     def pull_repository(self, language):
         output_dir = self.get_generated_lang_dir(language.language)


### PR DESCRIPTION
### What does this PR do?

A previous PR for the generate command shifted the return statement by one level of indentation, making it exit after processing the first language. This PR fixes it.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
