### PR TITLE
Fix tagging images with ':git-abcd123' on Dockerhub

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Tag the image both with the $IMAGE_NAME given and with $SOURCE_COMMIT
-docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME -t $DOCKER_REPO:git-${SOURCE_COMMIT:0:7} .

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Tag the image also with $SOURCE_COMMIT
+docker tag $IMAGE_NAME $DOCKER_REPO:git-${SOURCE_COMMIT:0:7}
+docker push $DOCKER_REPO:git-${SOURCE_COMMIT:0:7}


### PR DESCRIPTION
### What does this PR do?

The additional tags actually have to be added and pushed in `post_push`, not `build`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
