### PR TITLE
Preserve components section when generating full spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.egg-info/
 **/*.pyc
 **/*.pyo
+.vscode/

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -75,7 +75,14 @@ class InitCommand(Command):
                         {
                             "components": {
                                 "schemas": {},
-                                "security_schemes": {},
+                                "parameters": {},
+                                "securitySchemes": {},
+                                "requestBodies": {},
+                                "responses": {},
+                                "headers": {},
+                                "examples": {},
+                                "links": {},
+                                "callbacks": {},
                             },
                             "security": [],
                             "tags": [],

--- a/apigentools/utils.py
+++ b/apigentools/utils.py
@@ -195,12 +195,19 @@ def write_full_spec(config, spec_dir, version, full_spec_file):
     full_spec = {
         "paths": {},
         "tags": [],
-         "components": {
-             "schemas": {},
-             "securitySchemes": {},
+        "components": {
+            "schemas": {},
+            "parameters": {},
+            "securitySchemes": {},
+            "requestBodies": {},
+            "responses": {},
+            "headers": {},
+            "examples": {},
+            "links": {},
+            "callbacks": {},
          },
-         "servers": [{"url": config.server_base_urls[version]}],
-         "security": []
+        "servers": [{"url": config.server_base_urls[version]}],
+        "security": []
      }
 
     for filename in filenames:
@@ -215,7 +222,14 @@ def write_full_spec(config, spec_dir, version, full_spec_file):
                 full_spec["paths"].update(loaded.get("paths", {}))
                 full_spec["tags"].extend(loaded.get("tags", []))
                 full_spec["components"]["schemas"].update(loaded.get("components", {}).get("schemas", {}))
+                full_spec["components"]["parameters"].update(loaded.get("components", {}).get("parameters", {}))
                 full_spec["components"]["securitySchemes"].update(loaded.get("components", {}).get("securitySchemes", {})),
+                full_spec["components"]["requestBodies"].update(loaded.get("components", {}).get("requestBodies", {})),
+                full_spec["components"]["responses"].update(loaded.get("components", {}).get("responses", {})),
+                full_spec["components"]["headers"].update(loaded.get("components", {}).get("headers", {})),
+                full_spec["components"]["examples"].update(loaded.get("components", {}).get("examples", {})),
+                full_spec["components"]["links"].update(loaded.get("components", {}).get("links", {})),
+                full_spec["components"]["callbacks"].update(loaded.get("components", {}).get("callbacks", {})),
                 full_spec["security"].extend(loaded.get("security", {}))
 
     with open(fs_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
### What does this PR do?

When merging spec files into the final `full_spec.yaml`, ensures all the contents from the `components` section are carried over.

The `shared.yaml` template created with `init` was fixed accordingly.

### Motivation

I've got broken refs in my final spec due to missing `responses` and `requestBodies` sections.

### Additional Notes

I've added all the `components` sections according to https://swagger.io/docs/specification/components/ even if I don't use them all.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
