### PR TITLE
Cli argument with 'nargs=*' is automatically a list

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -86,7 +86,6 @@ def get_cli_parser():
         nargs="*",
         help="Additional components to add to the 'apigentoolsStamp' variable passed to templates",
         default=env_or_val("APIGENTOOLS_ADDITIONAL_STAMP", [], __type=list),
-        type=list,
     )
     generate_parser.add_argument(
         "-i", "--generated-with-image",


### PR DESCRIPTION
### What does this PR do?

Marking argument like this as `list` actually made it split it's string values into strings, so instead of `["some-stamp"]`, this would yield `["s", "o", "m", "e", "-", "s", "t", "a", "m", "p"]`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
