### PR TITLE
Raise error if duplicate fields across spec files

### DIFF
--- a/apigentools/utils.py
+++ b/apigentools/utils.py
@@ -15,6 +15,17 @@ from apigentools.constants import HEADER_FILE_NAME, SHARED_SECTION_NAME, REDACTE
 
 log = logging.getLogger(__name__)
 
+COMPONENT_FIELDS = [
+    'schemas',
+    'parameters',
+    'securitySchemes',
+    'requestBodies',
+    'responses',
+    'headers',
+    'examples',
+    'links',
+    'callbacks',
+]
 
 def set_log(log):
     fmt = logging.Formatter("%(levelname)s: %(message)s")
@@ -221,16 +232,16 @@ def write_full_spec(config, spec_dir, version, full_spec_file):
             else:
                 full_spec["paths"].update(loaded.get("paths", {}))
                 full_spec["tags"].extend(loaded.get("tags", []))
-                full_spec["components"]["schemas"].update(loaded.get("components", {}).get("schemas", {}))
-                full_spec["components"]["parameters"].update(loaded.get("components", {}).get("parameters", {}))
-                full_spec["components"]["securitySchemes"].update(loaded.get("components", {}).get("securitySchemes", {})),
-                full_spec["components"]["requestBodies"].update(loaded.get("components", {}).get("requestBodies", {})),
-                full_spec["components"]["responses"].update(loaded.get("components", {}).get("responses", {})),
-                full_spec["components"]["headers"].update(loaded.get("components", {}).get("headers", {})),
-                full_spec["components"]["examples"].update(loaded.get("components", {}).get("examples", {})),
-                full_spec["components"]["links"].update(loaded.get("components", {}).get("links", {})),
-                full_spec["components"]["callbacks"].update(loaded.get("components", {}).get("callbacks", {})),
                 full_spec["security"].extend(loaded.get("security", {}))
+
+                for field in COMPONENT_FIELDS:
+                    # Validate there aren't duplicate fields across files
+                    # Note: This won't raise an error if there is a duplicate component in a single file
+                    # That would alredy be deduped by the safe_load above.
+                    for key in loaded.get('components', {}).get(field, {}).keys():
+                        if key in full_spec.get('components', {}).get(field, {}):
+                            raise ValueError("Duplicate field {} found in spec. Exiting".format(key))
+                    full_spec["components"][field].update(loaded.get("components", {}).get(field, {}))
 
     with open(fs_path, "w", encoding="utf-8") as f:
         f.write(yaml.dump(full_spec))


### PR DESCRIPTION
### What does this PR do?

Slightly cleaner dict updates and detect + raise if there are duplicate components across files. 

### Motivation

Cleanup + more error detection

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
