### PR TITLE
Store git hash in image to improve the guarantee of reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM fedora:30
 
-ENV APIGENTOOLS_SPEC_REPO_DIR=/var/lib/apigentools/spec-repo
+ENV APIGENTOOLS_BASE_DIR=/var/lib/apigentools
+
+# _APIGENTOOLS_GIT_HASH_FILE is only for internal use, which is why it's prefixed with "_"
+ENV APIGENTOOLS_SPEC_REPO_DIR=${APIGENTOOLS_BASE_DIR}/spec-repo \
+    _APIGENTOOLS_GIT_HASH_FILE=${APIGENTOOLS_BASE_DIR}/git-hash
 
 ENV OPENAPI_GENERATOR_VERSION=4.1.1 \
     PACKAGES="docker findutils git golang-googlecode-tools-goimports java npm patch python3 python3-pip unzip"
@@ -22,3 +26,6 @@ COPY . /tmp/apigentools
 
 ARG APIGENTOOLS_SOURCE=/tmp/apigentools
 RUN pip3 install --prefix /usr ${APIGENTOOLS_SOURCE}
+
+ARG APIGENTOOLS_COMMIT=""
+RUN echo ${APIGENTOOLS_COMMIT} > ${_APIGENTOOLS_GIT_HASH_FILE}

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --build-arg APIGENTOOLS_COMMIT=${SOURCE_COMMIT} -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
### What does this PR do?

Right now, we're tagging apigentools images on Dockerhub with `:git-abcd123` tags in order to know what git hash they're built off (this gets placed in `.apigentools-info` on regeneration to ensure reproducibility.

The problem here is that when user pulls `:latest`, the other tags don't get pulled for it, so `:latest` is what ends up in `.apigentools-info`, which is not useful.

This PR makes sure that the git hash is stored inside the image, which makes it always available.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
