### PR TITLE
Fix downstream template rendering when full path to the target doesn't exist

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -96,6 +96,8 @@ class GenerateCommand(Command):
                     self.get_generated_lang_dir(language),
                     relative_path,
                 )
+                # build the full path to the target if doesn't exist
+                os.makedirs(os.path.dirname(target_path), exist_ok=True)
                 log.info("Writing {target}".format(target=target_path))
                 with open(template_path) as temp, open(target_path, "w") as target:
                     target.write(chevron.render(temp, settings))


### PR DESCRIPTION
### What does this PR do?

At downstream template rendering time, it creates the full path to a target if parent folders don't exist.

### Motivation

The first time you add a downstream template that's not a file at the root of the client repo (e.g. a folder containing some files), `render_downstream_templates` fails because the call to `open` can't find the target file for writing.

### Additional Notes

`os.makedirs` doesn't come for free and in almost any case the full path will be already there. In my use case the difference in negligible but I wanted to point this out in case you want to discuss a different approach.

I couldn't find an existing test to cover this case, in case you want one, any pointer on how to add it will be appreciated.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
