### PR TITLE
Option to use oauth token for git operations

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -28,7 +28,6 @@ def get_cli_parser():
     )
     p.add_argument(
         '--git-via-https-oauth-token',
-        action='store_true',
         default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN', ''),
         help='Insert OAuth token in the repo URL when using HTTPS for interacting with the git repositories.'
     )

--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -27,9 +27,9 @@ def get_cli_parser():
         help='Use HTTPS for interacting with the git repositories. Otherwise use SSH.'
     )
     p.add_argument(
-        '--git-via-https-token',
+        '--git-via-https-oauth-token',
         action='store_true',
-        default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS_TOKEN', ''),
+        default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN', ''),
         help='Insert OAuth token in the repo URL when using HTTPS for interacting with the git repositories.'
     )
     p.add_argument(

--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -27,6 +27,12 @@ def get_cli_parser():
         help='Use HTTPS for interacting with the git repositories. Otherwise use SSH.'
     )
     p.add_argument(
+        '--git-via-https-token',
+        action='store_true',
+        default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS_TOKEN', ''),
+        help='Insert OAuth token in the repo URL when using HTTPS for interacting with the git repositories.'
+    )
+    p.add_argument(
         "-r", "--spec-repo-dir",
         default=env_or_val("APIGENTOOLS_SPEC_REPO_DIR", "."),
         help="Switch to this directory before doing anything else",

--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -288,8 +288,8 @@ class GenerateCommand(Command):
         output_dir = self.get_generated_lang_dir(language.language)
         if self.args.git_via_https:
             oauth_url = ''
-            if self.args.git_via_https_token:
-                oauth_url = '{}:x-oauth-basic@'.format(self.args.git_via_https_token)
+            if self.args.git_via_https_oauth_token:
+                oauth_url = '{}:x-oauth-basic@'.format(self.args.git_via_https_oauth_token)
             repo = REPO_HTTPS_URL.format(
                 oauth_url,
                 language.github_org,

--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -21,7 +21,7 @@ from apigentools.utils import change_cwd, get_current_commit, run_command, write
 log = logging.getLogger(__name__)
 
 REPO_SSH_URL = 'git@github.com:{}/{}.git'
-REPO_HTTPS_URL = 'https://github.com/{}/{}.git'
+REPO_HTTPS_URL = 'https://{}github.com/{}/{}.git'
 
 
 class GenerateCommand(Command):
@@ -287,7 +287,14 @@ class GenerateCommand(Command):
     def pull_repository(self, language):
         output_dir = self.get_generated_lang_dir(language.language)
         if self.args.git_via_https:
-            repo = REPO_HTTPS_URL.format(language.github_org, language.github_repo)
+            oauth_url = ''
+            if self.args.git_via_https_token:
+                oauth_url = '{}:x-oauth-basic@'.format(self.args.git_via_https_token)
+            repo = REPO_HTTPS_URL.format(
+                oauth_url,
+                language.github_org,
+                language.github_repo
+            )
         else:
             repo = REPO_SSH_URL.format(language.github_org, language.github_repo)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ Argument | Description | Environment Variable | Default
 `-l LANGUAGES, --languages LANGUAGES` | Languages to run the specified action against. These must match what the config in the spec repo contains. Example: `apigentools -l go -l java test` | `APIGENTOOLS_LANG` | `None` to run against all
 `-r SPEC_REPO_DIR, --spec-repo-dir SPEC_REPO_DIR` | Switch to this directory before doing anything else | `APIGENTOOLS_SPEC_REPO_DIR` | `.`
 `--git-via-https` | Whether to use https (or ssh) for git actions | `APIGENTOOLS_GIT_VIA_HTTPS` | `false`
+`--git-via-https-token` | Use OAuth over HTTPS passing this token for git actions | `APIGENTOOLS_GIT_VIA_HTTPS_TOKEN` |
 `-v, --verbose` | Whether or not to log the generation in verbose mode
 
 ## `apigentools generate`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ Argument | Description | Environment Variable | Default
 `-l LANGUAGES, --languages LANGUAGES` | Languages to run the specified action against. These must match what the config in the spec repo contains. Example: `apigentools -l go -l java test` | `APIGENTOOLS_LANG` | `None` to run against all
 `-r SPEC_REPO_DIR, --spec-repo-dir SPEC_REPO_DIR` | Switch to this directory before doing anything else | `APIGENTOOLS_SPEC_REPO_DIR` | `.`
 `--git-via-https` | Whether to use https (or ssh) for git actions | `APIGENTOOLS_GIT_VIA_HTTPS` | `false`
-`--git-via-https-token` | Use OAuth over HTTPS passing this token for git actions | `APIGENTOOLS_GIT_VIA_HTTPS_TOKEN` |
+`--git-via-https-oauth-token` | Use OAuth over HTTPS passing this token for git actions | `APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN` |
 `-v, --verbose` | Whether or not to log the generation in verbose mode
 
 ## `apigentools generate`


### PR DESCRIPTION
### What does this PR do?

This is mostly a POC to show a possible solution to address the problem of running `apigentools` within a CI environment. I'm not sure a new option is the way to go but it was the least intrusive from the diff perspective, happy to discuss alternatives.

The PR simply adds a way to pass a "personal access token" through the command line that can be used to provide [OAuth credentials over HTTPS](https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/).

This is how my Github workflow uses this feature:

```
      - name: Generate clients
        env:
          APIGENTOOLS_GIT_VIA_HTTPS: true
          APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
        run: apigentools generate --builtin-templates --clone-repo
```

### Motivation

When running `apigentools` from a CI, commands like `generate --clone-repo` and `push` might require credentials to access the target git repos and the current CLI doesn't provide much flexibility to setup authentication.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
