### PR TITLE
Push to default branch if it doesn't exist, allow doing dry runs of push

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -240,6 +240,17 @@ def get_cli_parser():
         help='Message to use for the commit when pushing the auto generated clients',
         default=env_or_val("APIGENTOOLS_COMMIT_MSG", '')
     )
+    push_parser.add_argument(
+        "--default-branch",
+        help="Default branch of client repo - if it doesn't exist, it will be created and pushed to instead of a new feature branch",
+        default=env_or_val("APIGENTOOLS_DEFAULT_PUSH_BRANCH", "master"),
+    )
+    push_parser.add_argument(
+        "--dry-run",
+        help="Do a dry run of push (don't actually create and push new branches)",
+        action="store_true",
+        default=False,
+    )
 
     init_parser = sp.add_parser(
         "init",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,7 +59,9 @@ The generated directory is left in the branch that was checked out to push the c
 Argument | Description | Environment Variable | Default
 ---------|-------------|----------------------|--------
 `-h, --help` | Show help message and exit
-`--push-commit-msg` | Commit message to use when pushing the generated clients. || `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
+`--default-branch` | Default branch of client repo - if it doesn't exist, it will be created and pushed to instead of a new feature branch | `APIGENTOOLS_DEFAULT_PUSH_BRANCH` | `master`
+`--dry-run` | Do a dry run (do not actualy create branches/commits or push) | | `False`
+`--push-commit-msg` | Commit message to use when pushing the generated clients. | `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
 
 ## `apigentools split`
 


### PR DESCRIPTION
### What does this PR do?

Improves the `apigentools push` command in several ways:

* Makes it accept `--default-branch` argument to determine which branch is "default"
* Makes it push to the default branch if it doesn't exist on the remote repo
* Makes it possible to do a dry run of the push command to see what commands would be run

### Motivation

https://github.com/DataDog/apigentools/issues/43

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
