### PR TITLE
Add option to pass extra args to `openapi-generator`

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -266,6 +266,9 @@ class GenerateCommand(Command):
                 if not self.args.builtin_templates:
                     generate_cmd.extend(["-t", os.path.join(self.args.template_dir, language)])
 
+                if language_config.generate_extra_args:
+                    generate_cmd.extend(language_config.generate_extra_args)
+
                 os.makedirs(version_output_dir, exist_ok=True)
                 self.run_language_commands(language, "pre", version_output_dir)
 

--- a/apigentools/config.py
+++ b/apigentools/config.py
@@ -61,7 +61,7 @@ class LanguageConfig:
         return self.raw_dict.get("upstream_templates_dir", self.language)
 
     def __getattr__(self, attr):
-        return self.raw_dict[attr]
+        return self.raw_dict.get(attr)
 
     def get_stage_commands(self, stage):
         cmds = self.raw_dict.get("commands", {}).get(stage, [])

--- a/apigentools/config.py
+++ b/apigentools/config.py
@@ -61,7 +61,7 @@ class LanguageConfig:
         return self.raw_dict.get("upstream_templates_dir", self.language)
 
     def __getattr__(self, attr):
-        return self.raw_dict.get(attr)
+        return self.raw_dict[attr]
 
     def get_stage_commands(self, stage):
         cmds = self.raw_dict.get("commands", {}).get(stage, [])
@@ -81,6 +81,10 @@ class LanguageConfig:
     @property
     def command_env(self):
         return self.raw_dict.get("command_env", {})
+
+    @property
+    def generate_extra_args(self):
+        return self.raw_dict.get("generate_extra_args", [])
 
 
 class LanguageCommand:


### PR DESCRIPTION
### What does this PR do?

It adds a `generate_extra_args` key to the languages config containing a list of extra arguments that will be passed to `openapi-generator generate` when executing the command.

### Motivation

The Go generator has one quirk in the way it handles data of type ANY that's blocking me. A workaround was suggested by the OpenApi folks that consists of using the `--type-mappings` option of the `generate` command. Unfortunately, with the current logic I can't make this option pass through `apigentools` (note that this option will be only passed to the Go generator, so it has to be per-language).

### Additional Notes

There are plenty of ways to implement this but the proposed change is what looked more future proof to me. As usual, happy to discuss alternatives!

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
