### PR TITLE
Properly recognize list of languages if given by APIGENTOOLS_LANG

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -55,7 +55,7 @@ def get_cli_parser():
     p.add_argument(
         "-l", "--languages",
         action="append",
-        default=env_or_val("APIGENTOOLS_LANG", None),
+        default=env_or_val("APIGENTOOLS_LANG", None, __type=list),
         help="The language to run the specified action against. These must match what the config in the spec repo contains. Ex: 'apigentools -l go -l java test' (Default: None to run all)",
     )
     p.add_argument(


### PR DESCRIPTION
### What does this PR do?

Fix recognition of languages list when given by `APIGENTOOLS_LANG` (previously this would split the string character by character which made it unusable, now it would properly split it on colons, e.g. `APIGENTOOLS_LANG=java:go` is now possible).

### Motivation

Provide the possibility to pass `APIGENTOOLS_LANG` for containerized version of apigentools.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
