### PR TITLE
Fix destination dir name for processed templates

### DIFF
--- a/apigentools/commands/templates.py
+++ b/apigentools/commands/templates.py
@@ -34,7 +34,7 @@ class TemplatesCommand(Command):
                             self.args.local_path, lang_upstream_templates_dir, self.args.local_path
                         )
                         return 1
-                    shutil.copytree(local_lang_dir, os.path.join(td, lang))
+                    shutil.copytree(local_lang_dir, os.path.join(td, lang_upstream_templates_dir))
             else:
                 patch_in = copy_from = os.path.join(
                     td, "modules", "openapi-generator", "src", "main", "resources"
@@ -67,7 +67,7 @@ class TemplatesCommand(Command):
             # copy the processed templates from the temporary dir to templates dir
             languages = self.args.languages or self.config.languages
             for lang in languages:
-                upstream_templatedir = self.config.languages[lang].get("upstream_templates_dir", lang)
+                upstream_templatedir = self.config.get_language_config(lang).upstream_templates_dir
                 outlang_dir = os.path.join(self.args.output_dir, lang)
                 if os.path.exists(outlang_dir):
                     shutil.rmtree(outlang_dir)


### PR DESCRIPTION
### What does this PR do?

Changes the destination folder of templates processed by the command `template` from the name of the language (e.g. `javascript`) to the value of `upstream_templates_dir` (e.g. `Javascript`).

### Motivation

The `upstream_templates_dir` is used when copying templates to the staging temporary folder before the patching but then, the final templates are copied to a folder named after the language. This is a problem when the name of the language doesn't match the name of the folder containing the templates (for example, `html2` templates are stored in a folder called `htmlDocs2`): in this case the final copy under the `templates` folder fails.

### Additional Notes

Change at line 70 is unrelated but it was done to keep consistency with the rest of the module.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
