### PR TITLE
Allow git via https authentication as a Github app via installation access token

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -26,10 +26,16 @@ def get_cli_parser():
         default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS', False, __type=bool),
         help='Use HTTPS for interacting with the git repositories. Otherwise use SSH.'
     )
-    p.add_argument(
+    git_token_group = p.add_mutually_exclusive_group()
+    git_token_group.add_argument(
         '--git-via-https-oauth-token',
         default=env_or_val('APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN', ''),
         help='Insert OAuth token in the repo URL when using HTTPS for interacting with the git repositories.'
+    )
+    git_token_group.add_argument(
+        "--git-via-https-installation-access-token",
+        default=env_or_val("APIGENTOOLS_GIT_VIA_HTTPS_INSTALLATION_ACCESS_TOKEN", ""),
+        help="Insert installation access token (authenticate as Github app) in the repo URL when using HTTPS for interacting with the git repositories.",
     )
     p.add_argument(
         "-r", "--spec-repo-dir",

--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -290,11 +290,13 @@ class GenerateCommand(Command):
     def pull_repository(self, language):
         output_dir = self.get_generated_lang_dir(language.language)
         if self.args.git_via_https:
-            oauth_url = ''
+            checkout_url = ""
             if self.args.git_via_https_oauth_token:
-                oauth_url = '{}:x-oauth-basic@'.format(self.args.git_via_https_oauth_token)
+                checkout_url = "{}:x-oauth-basic@".format(self.args.git_via_https_oauth_token)
+            elif self.args.git_via_https_installation_access_token:
+                checkout_url = "x-access-token:{}@".format(self.args.git_via_https_installation_access_token)
             repo = REPO_HTTPS_URL.format(
-                oauth_url,
+                checkout_url,
                 language.github_org,
                 language.github_repo
             )

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,8 @@ Argument | Description | Environment Variable | Default
 `-l LANGUAGES, --languages LANGUAGES` | Languages to run the specified action against. These must match what the config in the spec repo contains. Example: `apigentools -l go -l java test` | `APIGENTOOLS_LANG` | `None` to run against all
 `-r SPEC_REPO_DIR, --spec-repo-dir SPEC_REPO_DIR` | Switch to this directory before doing anything else | `APIGENTOOLS_SPEC_REPO_DIR` | `.`
 `--git-via-https` | Whether to use https (or ssh) for git actions | `APIGENTOOLS_GIT_VIA_HTTPS` | `false`
-`--git-via-https-oauth-token` | Use OAuth over HTTPS passing this token for git actions | `APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN` |
+`--git-via-https-installation-access-token` | Use installation access token (authenticating a Github app) for git actions. Mutually exclusive with `--git-via-https-oauth-token`. | `APIGENTOOLS_GIT_VIA_HTTPS_INSTALLATION_ACCESS_TOKEN` |
+`--git-via-https-oauth-token` | Use OAuth over HTTPS passing this token for git actions. Mutually exclusive with `--git-via-https-installation-access-token`. | `APIGENTOOLS_GIT_VIA_HTTPS_OAUTH_TOKEN` |
 `-v, --verbose` | Whether or not to log the generation in verbose mode
 
 ## `apigentools generate`


### PR DESCRIPTION
### What does this PR do?

Makes it possible to authenticate as a Github app for git operations that apigentools do.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
