### PR TITLE
Allow skipping pushes for repos with no changes

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -257,6 +257,12 @@ def get_cli_parser():
         action="store_true",
         default=False,
     )
+    push_parser.add_argument(
+        "--skip-if-no-changes",
+        help="Skip committing/pushing for all repositories where only .apigentools has changed",
+        action="store_true",
+        default=env_or_val("APIGENTOOLS_SKIP_IF_NO_CHANGES", False, __type=bool),
+    )
 
     init_parser = sp.add_parser(
         "init",

--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -259,7 +259,7 @@ def get_cli_parser():
     )
     push_parser.add_argument(
         "--skip-if-no-changes",
-        help="Skip committing/pushing for all repositories where only .apigentools has changed",
+        help="Skip committing/pushing for all repositories where only .apigentools-info has changed",
         action="store_true",
         default=env_or_val("APIGENTOOLS_SKIP_IF_NO_CHANGES", False, __type=bool),
     )

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -41,9 +41,10 @@ class PushCommand(Command):
             line = line.strip()
             if line:
                 k, v = line.split(maxsplit=1)
-                result[k] = v
+                result.setdefault(k, [])
+                result[k].append(v)
 
-        if result == {} or result == {"M": ".apigentools"}:
+        if result == {} or result == {"M": [".apigentools-info"]}:
             return True
         return False
 

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -33,6 +33,20 @@ class PushCommand(Command):
             pass
         return push_branch
 
+    def git_status_empty(self):
+        # I hope that `--porcelain` doesn't mean this is fragile ¯\_(ツ)_/¯
+        status = run_command(["git", "status", "--porcelain"])
+        result = {}
+        for line in status.stdout.splitlines():
+            line = line.strip()
+            if line:
+                k, v = line.split(maxsplit=1)
+                result[k] = v
+
+        if result == {} or result == {"M": ".apigentools"}:
+            return True
+        return False
+
     def run(self):
         created_branches = {}
         cmd_result = 0
@@ -45,6 +59,7 @@ class PushCommand(Command):
             # Skip any languages not specified by the user
             if lang_name not in languages:
                 continue
+            log.info("Running push for language {}".format(lang_name))
 
             gen_dir = self.get_generated_lang_dir(lang_name)
             # Assumes all generated changes are in the gen_dir directory
@@ -53,6 +68,9 @@ class PushCommand(Command):
                 repo = "{}/{}".format(lang_config.github_org, lang_config.github_repo)
                 branch_name = self.get_push_branch(lang_name)
                 try:
+                    if self.args.skip_if_no_changes and self.git_status_empty():
+                        log.info("Only .apigentools file changed for language {}, skipping".format(lang_name))
+                        continue
                     run_command(['git', 'checkout', '-b', branch_name], dry_run=self.args.dry_run)
                     run_command(['git', 'add', '-A'], dry_run=self.args.dry_run)
                     run_command(['git', 'commit', '-a', '-m', commit_msg], dry_run=self.args.dry_run)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,6 +63,7 @@ Argument | Description | Environment Variable | Default
 `--default-branch` | Default branch of client repo - if it doesn't exist, it will be created and pushed to instead of a new feature branch | `APIGENTOOLS_DEFAULT_PUSH_BRANCH` | `master`
 `--dry-run` | Do a dry run (do not actualy create branches/commits or push) | | `False`
 `--push-commit-msg` | Commit message to use when pushing the generated clients. | `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
+`--skip-if-no-changes` | Skip committing/pushing for all repositories where only `.apigentools` has changed | `APIGENTOOLS_SKIP_IF_NO_CHANGES` | `False`
 
 ## `apigentools split`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,7 +63,7 @@ Argument | Description | Environment Variable | Default
 `--default-branch` | Default branch of client repo - if it doesn't exist, it will be created and pushed to instead of a new feature branch | `APIGENTOOLS_DEFAULT_PUSH_BRANCH` | `master`
 `--dry-run` | Do a dry run (do not actualy create branches/commits or push) | | `False`
 `--push-commit-msg` | Commit message to use when pushing the generated clients. | `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
-`--skip-if-no-changes` | Skip committing/pushing for all repositories where only `.apigentools` has changed | `APIGENTOOLS_SKIP_IF_NO_CHANGES` | `False`
+`--skip-if-no-changes` | Skip committing/pushing for all repositories where only `.apigentools-info` has changed | `APIGENTOOLS_SKIP_IF_NO_CHANGES` | `False`
 
 ## `apigentools split`
 


### PR DESCRIPTION
### What does this PR do?

Makes it possible to skip the `push` command for repos that have no changes (or just `.apigentools` changed).

### Motivation

Reducing noise in the branches created/pushed - we only want to see branches that actually have some changes.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
