### PR TITLE
Allow new git_name and git_email variables

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -242,11 +242,6 @@ def get_cli_parser():
         help="Push the generated source code into each git repository specified in the config",
     )
     push_parser.add_argument(
-        '--push-commit-msg',
-        help='Message to use for the commit when pushing the auto generated clients',
-        default=env_or_val("APIGENTOOLS_COMMIT_MSG", '')
-    )
-    push_parser.add_argument(
         "--default-branch",
         help="Default branch of client repo - if it doesn't exist, it will be created and pushed to instead of a new feature branch",
         default=env_or_val("APIGENTOOLS_DEFAULT_PUSH_BRANCH", "master"),
@@ -258,11 +253,27 @@ def get_cli_parser():
         default=False,
     )
     push_parser.add_argument(
+        '--push-commit-msg',
+        help='Message to use for the commit when pushing the auto generated clients',
+        default=env_or_val("APIGENTOOLS_COMMIT_MSG", '')
+    )
+    push_parser.add_argument(
         "--skip-if-no-changes",
         help="Skip committing/pushing for all repositories where only .apigentools-info has changed",
         action="store_true",
         default=env_or_val("APIGENTOOLS_SKIP_IF_NO_CHANGES", False, __type=bool),
     )
+    push_parser.add_argument(
+        "--git-email",
+        help="Email of the user to author git commits as",
+        default=env_or_val("APIGENTOOLS_GIT_EMAIL", None),
+    )
+    push_parser.add_argument(
+        "--git-name",
+        help="Name of the user to author git commits as",
+        default=env_or_val("APIGENTOOLS_GIT_NAME", None),
+    )
+
 
     init_parser = sp.add_parser(
         "init",

--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -265,13 +265,13 @@ def get_cli_parser():
     )
     push_parser.add_argument(
         "--git-email",
-        help="Email of the user to author git commits as",
-        default=env_or_val("APIGENTOOLS_GIT_EMAIL", None),
+        help="Email of the user to author git commits as. Note this will permanently modify the local repos git config to use this author",
+        default=env_or_val("APIGENTOOLS_GIT_AUTHOR_EMAIL", None),
     )
     push_parser.add_argument(
         "--git-name",
-        help="Name of the user to author git commits as",
-        default=env_or_val("APIGENTOOLS_GIT_NAME", None),
+        help="Name of the user to author git commits as. Note this will permanently modify the local repos git config to use this author",
+        default=env_or_val("APIGENTOOLS_GIT_AUTHOR_NAME", None),
     )
 
 

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -72,6 +72,14 @@ class PushCommand(Command):
                     if self.args.skip_if_no_changes and self.git_status_empty():
                         log.info("Only .apigentools file changed for language {}, skipping".format(lang_name))
                         continue
+
+                    # Update git config for this repository to use the provided author's email/name
+                    # If not specified, use the setup from the system/global
+                    if self.args.git_email:
+                        run_command(['git', 'config', 'user.email', self.args.git_email])
+                    if self.args.git_name:
+                        run_command(['git', 'config', 'user.name', self.args.git_name])
+
                     run_command(['git', 'checkout', '-b', branch_name], dry_run=self.args.dry_run)
                     run_command(['git', 'add', '-A'], dry_run=self.args.dry_run)
                     run_command(['git', 'commit', '-a', '-m', commit_msg], dry_run=self.args.dry_run)

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -76,9 +76,9 @@ class PushCommand(Command):
                     # Update git config for this repository to use the provided author's email/name
                     # If not specified, use the setup from the system/global
                     if self.args.git_email:
-                        run_command(['git', 'config', 'user.email'], dry_run=self.args.dry_run)
+                        run_command(['git', 'config', 'user.email', self.args.git_email], dry_run=self.args.dry_run)
                     if self.args.git_name:
-                        run_command(['git', 'config', 'user.name'], dry_run=self.args.dry_run)
+                        run_command(['git', 'config', 'user.name', self.args.git_name], dry_run=self.args.dry_run)
 
                     run_command(['git', 'checkout', '-b', branch_name], dry_run=self.args.dry_run)
                     run_command(['git', 'add', '-A'], dry_run=self.args.dry_run)

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -75,9 +75,9 @@ class PushCommand(Command):
 
                     # Update git config for this repository to use the provided author's email/name
                     # If not specified, use the setup from the system/global
-                    if self.args.git_email:
+                    if self.args.git_email and not self.args.dry_run:
                         run_command(['git', 'config', 'user.email', self.args.git_email])
-                    if self.args.git_name:
+                    if self.args.git_name and not self.args.dry_run:
                         run_command(['git', 'config', 'user.name', self.args.git_name])
 
                     run_command(['git', 'checkout', '-b', branch_name], dry_run=self.args.dry_run)

--- a/apigentools/commands/push.py
+++ b/apigentools/commands/push.py
@@ -75,10 +75,10 @@ class PushCommand(Command):
 
                     # Update git config for this repository to use the provided author's email/name
                     # If not specified, use the setup from the system/global
-                    if self.args.git_email and not self.args.dry_run:
-                        run_command(['git', 'config', 'user.email', self.args.git_email])
-                    if self.args.git_name and not self.args.dry_run:
-                        run_command(['git', 'config', 'user.name', self.args.git_name])
+                    if self.args.git_email:
+                        run_command(['git', 'config', 'user.email'], dry_run=self.args.dry_run)
+                    if self.args.git_name:
+                        run_command(['git', 'config', 'user.name'], dry_run=self.args.dry_run)
 
                     run_command(['git', 'checkout', '-b', branch_name], dry_run=self.args.dry_run)
                     run_command(['git', 'add', '-A'], dry_run=self.args.dry_run)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,7 +67,7 @@ Argument | Description | Environment Variable | Default
 `--git-email` | Email of the user to author git commits as | `APIGENTOOLS_GIT_AUTHOR_EMAIL` | `None`
 `--git-name` | Name of the user to author git commits as | `APIGENTOOLSGIT_AUTHOR_NAME` | `None`
 
-**Note** Specifying the `--git-*` flags will modify the .gitc/onfig settings of each local repository pushed to via apigentools. This will not modify the global .gitc/onfig.
+**Note** Specifying the `--git-*` flags will modify the .git/config settings of each local repository pushed to via apigentools. This will not modify the global .git/config.
 
 ## `apigentools split`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,10 +64,10 @@ Argument | Description | Environment Variable | Default
 `--dry-run` | Do a dry run (do not actualy create branches/commits or push) | | `False`
 `--push-commit-msg` | Commit message to use when pushing the generated clients. | `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
 `--skip-if-no-changes` | Skip committing/pushing for all repositories where only `.apigentools-info` has changed | `APIGENTOOLS_SKIP_IF_NO_CHANGES` | `False`
-`--git-email` | Email of the user to author git commits as | `APIGENTOOLS_GIT_EMAIL` | `None`
-`--git-name` | Name of the user to author git commits as | `APIGENTOOLS_GIT_NAME` | `None`
+`--git-email` | Email of the user to author git commits as | `APIGENTOOLS_GIT_AUTHOR_EMAIL` | `None`
+`--git-name` | Name of the user to author git commits as | `APIGENTOOLSGIT_AUTHOR_NAME` | `None`
 
-**Note** Specifying the `--git-*` flags will modify the .gitconfig settings of each local repository pushed to via apigentools. This will not modify the global .gitconfig.
+**Note** Specifying the `--git-*` flags will modify the .gitc/onfig settings of each local repository pushed to via apigentools. This will not modify the global .gitc/onfig.
 
 ## `apigentools split`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,6 +64,10 @@ Argument | Description | Environment Variable | Default
 `--dry-run` | Do a dry run (do not actualy create branches/commits or push) | | `False`
 `--push-commit-msg` | Commit message to use when pushing the generated clients. | `APIGENTOOLS_COMMIT_MSG` | `Regenerate client from commit <XYZ> of spec repo`
 `--skip-if-no-changes` | Skip committing/pushing for all repositories where only `.apigentools-info` has changed | `APIGENTOOLS_SKIP_IF_NO_CHANGES` | `False`
+`--git-email` | Email of the user to author git commits as | `APIGENTOOLS_GIT_EMAIL` | `None`
+`--git-name` | Name of the user to author git commits as | `APIGENTOOLS_GIT_NAME` | `None`
+
+**Note** Specifying the `--git-*` flags will modify the .gitconfig settings of each local repository pushed to via apigentools. This will not modify the global .gitconfig.
 
 ## `apigentools split`
 


### PR DESCRIPTION
### What does this PR do?

Added two new config options for `apigentools push`:
* git-name
* git-email

Also re-ordered the sub flags of `push` to be defined in an alphabetic order. 

### Motivation

Being able to specify a git name and email for the author of the commits pushed by the `push `command. This allows a user to either use whats on the global system or otherwise allows us to modify the gitconfig of the repos that apigentools is committing to. 

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
