### PR TITLE
Bump openapi-generator to 4.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV APIGENTOOLS_BASE_DIR=/var/lib/apigentools
 ENV APIGENTOOLS_SPEC_REPO_DIR=${APIGENTOOLS_BASE_DIR}/spec-repo \
     _APIGENTOOLS_GIT_HASH_FILE=${APIGENTOOLS_BASE_DIR}/git-hash
 
-ENV OPENAPI_GENERATOR_VERSION=4.1.1 \
+ENV OPENAPI_GENERATOR_VERSION=4.1.3 \
     PACKAGES="docker findutils git golang-googlecode-tools-goimports java npm patch python3 python3-pip unzip"
 
 VOLUME ${APIGENTOOLS_SPEC_REPO_DIR}


### PR DESCRIPTION
### What does this PR do?

Openapi-generator 4.1.3 is out that includes the PR for supporting multi api keys for the go client, including other things. 

https://github.com/OpenAPITools/openapi-generator/releases/tag/v4.1.3

### Motivation

We get the latest and greatest features. 

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
