### PR TITLE
add integration tests that import commands

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,34 +8,29 @@ from apigentools.commands.init import InitCommand
 # in case I need this later
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
     'fixtures',)
+
 def test_init():
     original_dir = os.getcwd()
-    git_dirs = {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
-    no_git_dirs = {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
-
-    try:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            os.chdir(temp_dir)
-            args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
-            cmd_instance = InitCommand({}, args)
-            cmd_instance.run()
-            #TODO - check that subdirectories and yaml are also correct
-            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-            #sets do not presume the output of os.walk() will be ordered
-            assert dir_entries == git_dirs
-        #test --no-git-repo
-        with tempfile.TemporaryDirectory() as temp_dir:
-            os.chdir(temp_dir)
-            args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
-            cmd_instance = InitCommand({}, args)
-            cmd_instance.run()
-            #TODO - check that subdirectories and yaml are also correct
-            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-            #sets do not presume the output of os.walk() will be ordered
-            assert dir_entries == no_git_dirs
-
-    # move back to original dir since tempdir is deleted on exiting with block
-    except Exception as e:
-        raise e
-    finally:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+        cmd_instance = InitCommand({}, args)
+        cmd_instance.run()
+        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+        #sets do not presume the output of os.walk() will be ordered
+        assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+        # move back to original dir since tempdir is deleted on exiting with block
         os.chdir(original_dir)
+
+    #test --no-git-repo
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+        cmd_instance = InitCommand({}, args)
+        cmd_instance.run()
+        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+        assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+        os.chdir(original_dir)
+
+        #TODO - check that subdirectories and yaml are also correct
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,14 +11,21 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 
 def test_init():
-    dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
-        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
-        cmd_instance = InitCommand({}, args)
-        cmd_instance.run()
-        #check that all created directories are present and correct
-        #TODO - check that subdirectories and yaml are also correct
-        with os.scandir(temp_dir) as scan_results:
-            dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
-        assert sorted(dir_names) == sorted(dir_entry_list)
+    original_dir = os.getcwd()
+    try:
+        dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            #check that all created directories are present and correct
+            #TODO - check that subdirectories and yaml are also correct
+            with os.scandir(temp_dir) as scan_results:
+                dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
+            assert sorted(dir_names) == sorted(dir_entry_list)
+    # move back to original dir since tempdir is deleted on exiting with block
+    except Exception as e:
+        raise e
+    finally:
+        os.chdir(original_dir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,5 +21,4 @@ def test_init():
         #TODO - check that subdirectories and yaml are also correct
         with os.scandir(temp_dir) as scan_results:
             dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
-        import pdb; pdb.set_trace()
         assert sorted(dir_names) == sorted(dir_entry_list)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+
+import flexmock
+import pytest
+
+from apigentools.commands.init import InitCommand
+# in case I need this later
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+    'fixtures',)
+
+
+def test_init():
+    dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+        cmd_instance = InitCommand({}, args)
+        cmd_instance.run()
+        #check that all created directories are present and correct
+        #TODO - check that subdirectories and yaml are also correct
+        with os.scandir(temp_dir) as scan_results:
+            dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
+        import pdb; pdb.set_trace()
+        assert sorted(dir_names) == sorted(dir_entry_list)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,9 @@ def test_init():
             cmd_instance.run()
             #sets do not presume the output of os.walk() will be ordered
             dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            # the layout of git repos has changed over time, this dir may or may not be present
+            if "./.git/branches" in dir_entries:
+                dir_entries.remove("./.git/branches")
             assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
 
         # move back to original dir since tempdir is deleted on exiting with block

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 
@@ -20,6 +21,7 @@ def test_init():
             #sets do not presume the output of os.walk() will be ordered
             dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
             assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+
         # move back to original dir since tempdir is deleted on exiting with block
     except Exception as e:
         raise e

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,8 +16,8 @@ def test_init():
         args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
         cmd_instance = InitCommand({}, args)
         cmd_instance.run()
-        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
         #sets do not presume the output of os.walk() will be ordered
+        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
         assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
         # move back to original dir since tempdir is deleted on exiting with block
         os.chdir(original_dir)
@@ -32,5 +32,5 @@ def test_init():
         assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
         os.chdir(original_dir)
 
-        #TODO - check that subdirectories and yaml are also correct
+        #TODO - check that json in files is json and is correct
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,17 +13,21 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 def test_init():
     original_dir = os.getcwd()
     try:
-        dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
+        top_dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
+            # TODO: check no_git_repo=True
             args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
             cmd_instance = InitCommand({}, args)
             cmd_instance.run()
             #check that all created directories are present and correct
             #TODO - check that subdirectories and yaml are also correct
-            with os.scandir(temp_dir) as scan_results:
-                dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
-            assert sorted(dir_names) == sorted(dir_entry_list)
+            dir_entries = [dir_entry[0] for dir_entry in os.walk(".")]
+            assert dir_entries == ['.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags']
+
+            # with os.scandir(temp_dir) as scan_results:
+            #     dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
+            # assert sorted(top_dir_names) == sorted(dir_entry_list)
     # move back to original dir since tempdir is deleted on exiting with block
     except Exception as e:
         raise e

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,26 +11,35 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 def test_init():
     original_dir = os.getcwd()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
-        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
-        cmd_instance = InitCommand({}, args)
-        cmd_instance.run()
-        #sets do not presume the output of os.walk() will be ordered
-        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-        assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            #sets do not presume the output of os.walk() will be ordered
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
         # move back to original dir since tempdir is deleted on exiting with block
+    except Exception as e:
+        raise e
+    finally:
         os.chdir(original_dir)
 
     #test --no-git-repo
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
-        args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
-        cmd_instance = InitCommand({}, args)
-        cmd_instance.run()
-        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-        assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+    except Exception as e:
+        raise e
+    finally:
         os.chdir(original_dir)
 
         #TODO - check that json in files is json and is correct
+
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,25 +9,18 @@ from apigentools.commands.init import InitCommand
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
     'fixtures',)
 
-
 def test_init():
     original_dir = os.getcwd()
     try:
-        top_dir_names = ["config", "generated", "template-patches", "downstream-templates", "spec", "templates", ".git"]
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
-            # TODO: check no_git_repo=True
             args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
             cmd_instance = InitCommand({}, args)
             cmd_instance.run()
-            #check that all created directories are present and correct
             #TODO - check that subdirectories and yaml are also correct
-            dir_entries = [dir_entry[0] for dir_entry in os.walk(".")]
-            assert dir_entries == ['.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags']
-
-            # with os.scandir(temp_dir) as scan_results:
-            #     dir_entry_list = [dir_entry.name for dir_entry in scan_results if dir_entry.is_dir() is True]
-            # assert sorted(top_dir_names) == sorted(dir_entry_list)
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            #sets do not presume the output of os.walk() will be ordered
+            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
     # move back to original dir since tempdir is deleted on exiting with block
     except Exception as e:
         raise e

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,9 +8,11 @@ from apigentools.commands.init import InitCommand
 # in case I need this later
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
     'fixtures',)
-
 def test_init():
     original_dir = os.getcwd()
+    git_dirs = {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+    no_git_dirs = {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+
     try:
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
@@ -20,7 +22,18 @@ def test_init():
             #TODO - check that subdirectories and yaml are also correct
             dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
             #sets do not presume the output of os.walk() will be ordered
-            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+            assert dir_entries == git_dirs
+        #test --no-git-repo
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            #TODO - check that subdirectories and yaml are also correct
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            #sets do not presume the output of os.walk() will be ordered
+            assert dir_entries == no_git_dirs
+
     # move back to original dir since tempdir is deleted on exiting with block
     except Exception as e:
         raise e


### PR DESCRIPTION
### What does this PR do?

This is an example of a new approach to integration testing that imports the commands and runs them, instead of using `subprocess`

### Motivation

Hippo's comments about the difficulty of debugging tests that use `subprocess`, discussed in Slack [here](https://dd.slack.com/archives/CHXRF0UG3/p1573665887139800)


### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
