### PR TITLE
Refactor InitCommand class so that json written to file is importable 

### DIFF
--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -17,40 +17,40 @@ log = logging.getLogger(__name__)
 
 class InitCommand(Command):
     config_file_json = {
-                        "codegen_exec": "openapi-generator",
-                        "languages": {},
-                        "server_base_urls": {
-                                "v1": "https://api.myserver.com/v1",
-                            },
-                        "spec_sections": {
-                                "v1": [],
-                            },
-                        "spec_versions": ["v1"],
-                            }
+                    "codegen_exec": "openapi-generator",
+                    "languages": {},
+                    "server_base_urls": {
+                        "v1": "https://api.myserver.com/v1",
+                        },
+                    "spec_sections": {
+                        "v1": [],
+                        },
+                    "spec_versions": ["v1"],
+    }
     v1_header_json = {
-                            "info": {
-                                "contact": {},
-                                "description": "Collection of all public API endpoints.",
-                                "title": "My API endpoints",
-                                "version": "1.0"
-                            },
-                            "openapi": "3.0.0",
-                        }
+                    "info": {
+                        "contact": {},
+                        "description": "Collection of all public API endpoints.",
+                        "title": "My API endpoints",
+                        "version": "1.0"
+                    },
+                    "openapi": "3.0.0",
+    }
     v1_shared_json = {
-                            "components": {
-                                "schemas": {},
-                                "parameters": {},
-                                "securitySchemes": {},
-                                "requestBodies": {},
-                                "responses": {},
-                                "headers": {},
-                                "examples": {},
-                                "links": {},
-                                "callbacks": {},
-                            },
-                            "security": [],
-                            "tags": [],
-                        }
+                    "components": {
+                        "schemas": {},
+                        "parameters": {},
+                        "securitySchemes": {},
+                        "requestBodies": {},
+                        "responses": {},
+                        "headers": {},
+                        "examples": {},
+                        "links": {},
+                        "callbacks": {},
+                    },
+                    "security": [],
+                    "tags": [],
+    }
     gitignore = [
         "!generated\n",
         "generated/*\n",
@@ -84,7 +84,7 @@ class InitCommand(Command):
             config_file = os.path.join(dirs["config_dir"], constants.DEFAULT_CONFIG_FILE)
             if not os.path.exists(config_file):
                 with open(config_file, "w") as f:
-                    json.dump(self.config_file_json,f,indent=4)
+                    json.dump(self.config_file_json, f, indent=4)
             v1_header = os.path.join(dirs["spec_v1_dir"], constants.HEADER_FILE_NAME)
             v1_shared = os.path.join(dirs["spec_v1_dir"], constants.SHARED_SECTION_NAME + ".yaml")
             if not os.path.exists(v1_header):

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -16,53 +16,51 @@ log = logging.getLogger(__name__)
 
 
 class InitCommand(Command):
-    def __init__(self, config, args):
-        self.config_file_json = {
-                                "codegen_exec": "openapi-generator",
-                                "languages": {},
-                                "server_base_urls": {
-                                    "v1": "https://api.myserver.com/v1",
-                                },
-                                "spec_sections": {
-                                    "v1": [],
-                                },
-                                "spec_versions": ["v1"],
+    config_file_json = {
+                        "codegen_exec": "openapi-generator",
+                        "languages": {},
+                        "server_base_urls": {
+                                "v1": "https://api.myserver.com/v1",
+                            },
+                        "spec_sections": {
+                                "v1": [],
+                            },
+                        "spec_versions": ["v1"],
                             }
-        self.v1_header_json = {
-                                "info": {
-                                    "contact": {},
-                                    "description": "Collection of all public API endpoints.",
-                                    "title": "My API endpoints",
-                                    "version": "1.0"
-                                },
-                                "openapi": "3.0.0",
-                            }
-        self.v1_shared_json = {
-                                "components": {
-                                    "schemas": {},
-                                    "parameters": {},
-                                    "securitySchemes": {},
-                                    "requestBodies": {},
-                                    "responses": {},
-                                    "headers": {},
-                                    "examples": {},
-                                    "links": {},
-                                    "callbacks": {},
-                                },
-                                "security": [],
-                                "tags": [],
-                            }
-        self.gitignore = [
-        "!generated\n",
-        "generated/*\n",
-        "!generated/.gitkeep\n",
-        "spec/*/full_spec.yaml\n",
-        "!templates\n",
-        "templates/*\n",
-        "templates/\n",
-        ".gitkeep/n"
-        ]
-        super().__init__(config, args)
+    v1_header_json = {
+                            "info": {
+                                "contact": {},
+                                "description": "Collection of all public API endpoints.",
+                                "title": "My API endpoints",
+                                "version": "1.0"
+                            },
+                            "openapi": "3.0.0",
+                        }
+    v1_shared_json = {
+                            "components": {
+                                "schemas": {},
+                                "parameters": {},
+                                "securitySchemes": {},
+                                "requestBodies": {},
+                                "responses": {},
+                                "headers": {},
+                                "examples": {},
+                                "links": {},
+                                "callbacks": {},
+                            },
+                            "security": [],
+                            "tags": [],
+                        }
+    gitignore = [
+    "!generated\n",
+    "generated/*\n",
+    "!generated/.gitkeep\n",
+    "spec/*/full_spec.yaml\n",
+    "!templates\n",
+    "templates/*\n",
+    "templates/\n",
+    ".gitkeep/n"
+    ]
 
     def run(self):
         cmd_result = 0

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -52,14 +52,14 @@ class InitCommand(Command):
                             "tags": [],
                         }
     gitignore = [
-    "!generated\n",
-    "generated/*\n",
-    "!generated/.gitkeep\n",
-    "spec/*/full_spec.yaml\n",
-    "!templates\n",
-    "templates/*\n",
-    "templates/\n",
-    ".gitkeep/n"
+        "!generated\n",
+        "generated/*\n",
+        "!generated/.gitkeep\n",
+        "spec/*/full_spec.yaml\n",
+        "!templates\n",
+        "templates/*\n",
+        "templates/\n",
+        ".gitkeep/n"
     ]
 
     def run(self):

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -21,10 +21,10 @@ class InitCommand(Command):
         "languages": {},
         "server_base_urls": {
             "v1": "https://api.myserver.com/v1",
-            },
+        },
         "spec_sections": {
             "v1": [],
-            },
+        },
         "spec_versions": ["v1"],
     }
     V1_HEADER_JSON = {

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -52,13 +52,16 @@ class InitCommand(Command):
                                 "security": [],
                                 "tags": [],
                             }
-        self.gitignore = "!generated\n \
-                    generated/*\n \
-                    !generated/.gitkeep\n \
-                    spec/*/full_spec.yaml\n \
-                    !templates\n \
-                    templates/*\n  \
-                    !templates/.gitkeep"
+        self.gitignore = [
+        "!generated\n",
+        "generated/*\n",
+        "!generated/.gitkeep\n",
+        "spec/*/full_spec.yaml\n",
+        "!templates\n",
+        "templates/*\n",
+        "templates/\n",
+        ".gitkeep/n"
+        ]
         super().__init__(config, args)
 
     def run(self):
@@ -100,5 +103,5 @@ class InitCommand(Command):
                         pass
                 if not os.path.exists(".gitignore"):
                     with open(".gitignore", "w") as f:
-                        f.write(self.gitignore)
+                        f.writelines(self.gitignore)
         return cmd_result

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -16,6 +16,51 @@ log = logging.getLogger(__name__)
 
 
 class InitCommand(Command):
+    def __init__(self, config, args):
+        self.config_file_json = {
+                                "codegen_exec": "openapi-generator",
+                                "languages": {},
+                                "server_base_urls": {
+                                    "v1": "https://api.myserver.com/v1",
+                                },
+                                "spec_sections": {
+                                    "v1": [],
+                                },
+                                "spec_versions": ["v1"],
+                            }
+        self.v1_header_json = {
+                                "info": {
+                                    "contact": {},
+                                    "description": "Collection of all public API endpoints.",
+                                    "title": "My API endpoints",
+                                    "version": "1.0"
+                                },
+                                "openapi": "3.0.0",
+                            }
+        self.v1_shared_json = {
+                                "components": {
+                                    "schemas": {},
+                                    "parameters": {},
+                                    "securitySchemes": {},
+                                    "requestBodies": {},
+                                    "responses": {},
+                                    "headers": {},
+                                    "examples": {},
+                                    "links": {},
+                                    "callbacks": {},
+                                },
+                                "security": [],
+                                "tags": [],
+                            }
+        self.gitignore = "!generated\n \
+                    generated/*\n \
+                    !generated/.gitkeep\n \
+                    spec/*/full_spec.yaml\n \
+                    !templates\n \
+                    templates/*\n  \
+                    !templates/.gitkeep"
+        super().__init__(config, args)
+
     def run(self):
         cmd_result = 0
         log.info("Initializing a new project directory")
@@ -38,58 +83,15 @@ class InitCommand(Command):
             config_file = os.path.join(dirs["config_dir"], constants.DEFAULT_CONFIG_FILE)
             if not os.path.exists(config_file):
                 with open(config_file, "w") as f:
-                    json.dump(
-                        {
-                            "codegen_exec": "openapi-generator",
-                            "languages": {},
-                            "server_base_urls": {
-                                "v1": "https://api.myserver.com/v1",
-                            },
-                            "spec_sections": {
-                                "v1": [],
-                            },
-                            "spec_versions": ["v1"],
-                        },
-                        f,
-                        indent=4,
-                    )
+                    json.dump(self.config_file_json,f,indent=4)
             v1_header = os.path.join(dirs["spec_v1_dir"], constants.HEADER_FILE_NAME)
             v1_shared = os.path.join(dirs["spec_v1_dir"], constants.SHARED_SECTION_NAME + ".yaml")
             if not os.path.exists(v1_header):
                 with open(v1_header, "w") as f:
-                    yaml.dump(
-                        {
-                            "info": {
-                                "contact": {},
-                                "description": "Collection of all public API endpoints.",
-                                "title": "My API endpoints",
-                                "version": "1.0"
-                            },
-                            "openapi": "3.0.0",
-                        },
-                        f
-                    )
+                    yaml.dump(self.v1_header_json, f)
             if not os.path.exists(v1_shared):
                 with open(v1_shared, "w") as f:
-                    yaml.dump(
-                        {
-                            "components": {
-                                "schemas": {},
-                                "parameters": {},
-                                "securitySchemes": {},
-                                "requestBodies": {},
-                                "responses": {},
-                                "headers": {},
-                                "examples": {},
-                                "links": {},
-                                "callbacks": {},
-                            },
-                            "security": [],
-                            "tags": [],
-                        },
-                        f
-                    )
-
+                    yaml.dump(self.v1_shared_json, f)
             if is_repo:
                 log.info("Creating a git repo in the new spec project directory")
                 run_command(["git", "init"], log_level=logging.DEBUG)
@@ -98,14 +100,5 @@ class InitCommand(Command):
                         pass
                 if not os.path.exists(".gitignore"):
                     with open(".gitignore", "w") as f:
-                        f.write(
-                            "!generated\n"
-                            "generated/*\n"
-                            "!generated/.gitkeep\n"
-                            "spec/*/full_spec.yaml\n"
-                            "!templates\n"
-                            "templates/*\n"
-                            "!templates/.gitkeep"
-                        )
-
+                        f.write(self.gitignore)
         return cmd_result

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -16,42 +16,42 @@ log = logging.getLogger(__name__)
 
 
 class InitCommand(Command):
-    config_file_json = {
-                    "codegen_exec": "openapi-generator",
-                    "languages": {},
-                    "server_base_urls": {
-                        "v1": "https://api.myserver.com/v1",
-                        },
-                    "spec_sections": {
-                        "v1": [],
-                        },
-                    "spec_versions": ["v1"],
+    CONFIG_FILE_JSON = {
+        "codegen_exec": "openapi-generator",
+        "languages": {},
+        "server_base_urls": {
+            "v1": "https://api.myserver.com/v1",
+            },
+        "spec_sections": {
+            "v1": [],
+            },
+        "spec_versions": ["v1"],
     }
-    v1_header_json = {
-                    "info": {
-                        "contact": {},
-                        "description": "Collection of all public API endpoints.",
-                        "title": "My API endpoints",
-                        "version": "1.0"
-                    },
-                    "openapi": "3.0.0",
+    V1_HEADER_JSON = {
+        "info": {
+            "contact": {},
+            "description": "Collection of all public API endpoints.",
+            "title": "My API endpoints",
+            "version": "1.0"
+        },
+        "openapi": "3.0.0",
     }
-    v1_shared_json = {
-                    "components": {
-                        "schemas": {},
-                        "parameters": {},
-                        "securitySchemes": {},
-                        "requestBodies": {},
-                        "responses": {},
-                        "headers": {},
-                        "examples": {},
-                        "links": {},
-                        "callbacks": {},
-                    },
-                    "security": [],
-                    "tags": [],
+    V1_SHARED_JSON = {
+        "components": {
+            "schemas": {},
+            "parameters": {},
+            "securitySchemes": {},
+            "requestBodies": {},
+            "responses": {},
+            "headers": {},
+            "examples": {},
+            "links": {},
+            "callbacks": {},
+        },
+        "security": [],
+        "tags": [],
     }
-    gitignore = [
+    GITIGNORE = [
         "!generated\n",
         "generated/*\n",
         "!generated/.gitkeep\n",
@@ -84,15 +84,15 @@ class InitCommand(Command):
             config_file = os.path.join(dirs["config_dir"], constants.DEFAULT_CONFIG_FILE)
             if not os.path.exists(config_file):
                 with open(config_file, "w") as f:
-                    json.dump(self.config_file_json, f, indent=4)
+                    json.dump(self.CONFIG_FILE_JSON, f, indent=4)
             v1_header = os.path.join(dirs["spec_v1_dir"], constants.HEADER_FILE_NAME)
             v1_shared = os.path.join(dirs["spec_v1_dir"], constants.SHARED_SECTION_NAME + ".yaml")
             if not os.path.exists(v1_header):
                 with open(v1_header, "w") as f:
-                    yaml.dump(self.v1_header_json, f)
+                    yaml.dump(self.V1_HEADER_JSON, f)
             if not os.path.exists(v1_shared):
                 with open(v1_shared, "w") as f:
-                    yaml.dump(self.v1_shared_json, f)
+                    yaml.dump(self.V1_SHARED_JSON, f)
             if is_repo:
                 log.info("Creating a git repo in the new spec project directory")
                 run_command(["git", "init"], log_level=logging.DEBUG)
@@ -101,5 +101,5 @@ class InitCommand(Command):
                         pass
                 if not os.path.exists(".gitignore"):
                     with open(".gitignore", "w") as f:
-                        f.writelines(self.gitignore)
+                        f.writelines(self.GITIGNORE)
         return cmd_result

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,14 @@ def test_init():
             # the layout of git repos has changed over time, this dir may or may not be present
             if "./.git/branches" in dir_entries:
                 dir_entries.remove("./.git/branches")
-            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+            assert dir_entries == {
+                '.', './generated', './template-patches',
+                './config', './config/languages', './downstream-templates',
+                './spec', './spec/v1', './templates', './.git',
+                './.git/objects', './.git/objects/pack',
+                './.git/objects/info', './.git/info', './.git/hooks',
+                './.git/refs', './.git/refs/heads', './.git/refs/tags'
+                }
 
         # move back to original dir since tempdir is deleted on exiting with block
     except Exception as e:
@@ -39,12 +46,13 @@ def test_init():
             cmd_instance = InitCommand({}, args)
             cmd_instance.run()
             dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+            assert dir_entries == {
+                '.', './generated', './template-patches', './config',
+                './config/languages', './downstream-templates', './spec',
+                './spec/v1', './templates'
+                }
     except Exception as e:
         raise e
     finally:
         os.chdir(original_dir)
-
-        #TODO - check that json in files is json and is correct
-
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,43 +7,27 @@ from apigentools.commands.init import InitCommand
 
 def test_init(tmpdir):
     original_dir = os.getcwd()
-    try:
-        temp_dir = tmpdir.mkdir("test_init_git_dir")
-        os.chdir(temp_dir)
-        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
-        cmd_instance = InitCommand({}, args)
-        cmd_instance.run()
-        #sets do not presume the output of os.walk() will be ordered
-        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-        # the layout of git repos has changed over time, this dir may or may not be present
-        if "./.git/branches" in dir_entries:
-            dir_entries.remove("./.git/branches")
-        assert dir_entries == {
-            '.', './generated', './template-patches',
-            './config', './config/languages', './downstream-templates',
-            './spec', './spec/v1', './templates', './.git',
-            './.git/objects', './.git/objects/pack',
-            './.git/objects/info', './.git/info', './.git/hooks',
-            './.git/refs', './.git/refs/heads', './.git/refs/tags'
-                }
-
-    # move back to original dir since temp_dir is deleted on exiting with block
-    finally:
-        os.chdir(original_dir)
+    temp_dir = tmpdir.mkdir("test_init_git_dir")
+    args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+    cmd_instance = InitCommand({}, args)
+    cmd_instance.run()
+    #sets do not presume the output of os.walk() will be ordered
+    dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
+    # the layout of git repos has changed over time, so only look for the top .git directory
+    test_dirs = {
+        os.path.join(temp_dir,'generated'), os.path.join(temp_dir,'template-patches'), os.path.join(temp_dir,'config'),
+        os.path.join(temp_dir,'config/languages'), os.path.join(temp_dir,'downstream-templates'),
+        os.path.join(temp_dir,'spec'), os.path.join(temp_dir,'spec/v1'), os.path.join(temp_dir,'templates'), os.path.join(temp_dir,'.git')}
+    assert test_dirs.issubset(dir_entries)
 
     #test --no-git-repo
-    try:
-        temp_dir = tmpdir.mkdir("test_init_no_git_dir")
-        os.chdir(temp_dir)
-        args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
-        cmd_instance = InitCommand({}, args)
-        cmd_instance.run()
-        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-        assert dir_entries == {
-            '.', './generated', './template-patches', './config',
-            './config/languages', './downstream-templates', './spec',
-            './spec/v1', './templates'
-            }
-
-    finally:
-        os.chdir(original_dir)
+    temp_dir = tmpdir.mkdir("test_init_no_git_dir")
+    args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+    cmd_instance = InitCommand({}, args)
+    cmd_instance.run()
+    dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
+    test_dirs = {
+        os.path.join(temp_dir,'generated'), os.path.join(temp_dir,'template-patches'), os.path.join(temp_dir,'config'),
+        os.path.join(temp_dir,'config/languages'), os.path.join(temp_dir,'downstream-templates'), temp_dir,
+        os.path.join(temp_dir,'spec'), os.path.join(temp_dir,'spec/v1'), os.path.join(temp_dir,'templates')}
+    assert dir_entries == test_dirs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,26 +10,26 @@ from apigentools.commands.init import InitCommand
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
     'fixtures',)
 
-def test_init():
+def test_init(tmpdir):
     original_dir = os.getcwd()
     try:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            os.chdir(temp_dir)
-            args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
-            cmd_instance = InitCommand({}, args)
-            cmd_instance.run()
-            #sets do not presume the output of os.walk() will be ordered
-            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-            # the layout of git repos has changed over time, this dir may or may not be present
-            if "./.git/branches" in dir_entries:
-                dir_entries.remove("./.git/branches")
-            assert dir_entries == {
-                '.', './generated', './template-patches',
-                './config', './config/languages', './downstream-templates',
-                './spec', './spec/v1', './templates', './.git',
-                './.git/objects', './.git/objects/pack',
-                './.git/objects/info', './.git/info', './.git/hooks',
-                './.git/refs', './.git/refs/heads', './.git/refs/tags'
+        temp_dir = tmpdir.mkdir("test_init_git_dir")
+        os.chdir(temp_dir)
+        args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+        cmd_instance = InitCommand({}, args)
+        cmd_instance.run()
+        #sets do not presume the output of os.walk() will be ordered
+        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+        # the layout of git repos has changed over time, this dir may or may not be present
+        if "./.git/branches" in dir_entries:
+            dir_entries.remove("./.git/branches")
+        assert dir_entries == {
+            '.', './generated', './template-patches',
+            './config', './config/languages', './downstream-templates',
+            './spec', './spec/v1', './templates', './.git',
+            './.git/objects', './.git/objects/pack',
+            './.git/objects/info', './.git/info', './.git/hooks',
+            './.git/refs', './.git/refs/heads', './.git/refs/tags'
                 }
 
     # move back to original dir since temp_dir is deleted on exiting with block

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,17 +16,17 @@ def test_init(tmpdir):
     # the layout of git repos has changed over time, so only look for the top
     # .git directory
     test_dirs = {
-        temp_dir,
-        os.path.join(temp_dir, 'generated'),
-        os.path.join(temp_dir, 'template-patches'),
-        os.path.join(temp_dir, 'config'),
-        os.path.join(temp_dir, 'config/languages'),
-        os.path.join(temp_dir, 'downstream-templates'),
-        os.path.join(temp_dir, 'spec'),
-        os.path.join(temp_dir, 'spec/v1'),
-        os.path.join(temp_dir, 'templates'),
-        os.path.join(temp_dir, '.git'),
-        }
+    temp_dir,
+    os.path.join(temp_dir, 'generated'),
+    os.path.join(temp_dir, 'template-patches'),
+    os.path.join(temp_dir, 'config'),
+    os.path.join(temp_dir, 'config/languages'),
+    os.path.join(temp_dir, 'downstream-templates'),
+    os.path.join(temp_dir, 'spec'),
+    os.path.join(temp_dir, 'spec/v1'),
+    os.path.join(temp_dir, 'templates'),
+    os.path.join(temp_dir, '.git'),
+    }
 
     assert test_dirs.issubset(dir_entries)
 
@@ -37,14 +37,14 @@ def test_init(tmpdir):
     cmd_instance.run()
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     test_dirs = {
-        temp_dir,
-        os.path.join(temp_dir, 'generated'),
-        os.path.join(temp_dir, 'template-patches'),
-        os.path.join(temp_dir, 'config'),
-        os.path.join(temp_dir, 'config/languages'),
-        os.path.join(temp_dir, 'downstream-templates'),
-        os.path.join(temp_dir, 'spec'),
-        os.path.join(temp_dir, 'spec/v1'),
-        os.path.join(temp_dir, 'templates')
+    temp_dir,
+    os.path.join(temp_dir, 'generated'),
+    os.path.join(temp_dir, 'template-patches'),
+    os.path.join(temp_dir, 'config'),
+    os.path.join(temp_dir, 'config/languages'),
+    os.path.join(temp_dir, 'downstream-templates'),
+    os.path.join(temp_dir, 'spec'),
+    os.path.join(temp_dir, 'spec/v1'),
+    os.path.join(temp_dir, 'templates')
         }
     assert dir_entries == test_dirs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,14 +1,9 @@
-import json
 import os
-import tempfile
 
 import flexmock
 import pytest
 
 from apigentools.commands.init import InitCommand
-# in case I need this later
-FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-    'fixtures',)
 
 def test_init(tmpdir):
     original_dir = os.getcwd()
@@ -52,4 +47,3 @@ def test_init(tmpdir):
 
     finally:
         os.chdir(original_dir)
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,9 +32,7 @@ def test_init():
                 './.git/refs', './.git/refs/heads', './.git/refs/tags'
                 }
 
-        # move back to original dir since tempdir is deleted on exiting with block
-    except Exception as e:
-        raise e
+    # move back to original dir since temp_dir is deleted on exiting with block
     finally:
         os.chdir(original_dir)
 
@@ -51,8 +49,7 @@ def test_init():
                 './config/languages', './downstream-templates', './spec',
                 './spec/v1', './templates'
                 }
-    except Exception as e:
-        raise e
+
     finally:
         os.chdir(original_dir)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,17 +38,17 @@ def test_init(tmpdir):
 
     #test --no-git-repo
     try:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            os.chdir(temp_dir)
-            args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
-            cmd_instance = InitCommand({}, args)
-            cmd_instance.run()
-            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
-            assert dir_entries == {
-                '.', './generated', './template-patches', './config',
-                './config/languages', './downstream-templates', './spec',
-                './spec/v1', './templates'
-                }
+        temp_dir = tmpdir.mkdir("test_init_no_git_dir")
+        os.chdir(temp_dir)
+        args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+        cmd_instance = InitCommand({}, args)
+        cmd_instance.run()
+        dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+        assert dir_entries == {
+            '.', './generated', './template-patches', './config',
+            './config/languages', './downstream-templates', './spec',
+            './spec/v1', './templates'
+            }
 
     finally:
         os.chdir(original_dir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,44 +5,33 @@ import pytest
 
 from apigentools.commands.init import InitCommand
 
-temp_dir = "/temp_dir"
-TEST_DIRS = {
-    temp_dir,
-    os.path.join(temp_dir, 'generated'),
-    os.path.join(temp_dir, 'template-patches'),
-    os.path.join(temp_dir, 'config'),
-    os.path.join(temp_dir, 'config/languages'),
-    os.path.join(temp_dir, 'downstream-templates'),
-    os.path.join(temp_dir, 'spec'),
-    os.path.join(temp_dir, 'spec/v1'),
-    os.path.join(temp_dir, 'templates'),
-}
+
+
 
 def test_init(tmpdir):
+    # directories created by init command
+    directory_names = {
+    'generated',
+    'template-patches',
+    'config',
+    os.path.join('config', 'languages'),
+    'downstream-templates',
+    'spec',
+    os.path.join('spec', 'v1'),
+    'templates',
+    }
     temp_dir = tmpdir.mkdir("test_init_git_dir")
     args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
     # sets do not presume the output of os.walk() will be ordered
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
-    # the layout of git repos has changed over time, so only look for the top
-    # .git directory
-    # test_dirs = {
-    # temp_dir,
-    # os.path.join(temp_dir, 'generated'),
-    # os.path.join(temp_dir, 'template-patches'),
-    # os.path.join(temp_dir, 'config'),
-    # os.path.join(temp_dir, 'config/languages'),
-    # os.path.join(temp_dir, 'downstream-templates'),
-    # os.path.join(temp_dir, 'spec'),
-    # os.path.join(temp_dir, 'spec/v1'),
-    # os.path.join(temp_dir, 'templates'),
-    # os.path.join(temp_dir, '.git'),
-    # }
-    TEST_DIRS = TEST_DIRS.add(os.path.join(temp_dir, '.git'))
-    assert TEST_DIRS.issubset(dir_entries)
-
-    # assert test_dirs.issubset(dir_entries)
+    # create a set of expected directory names to test against
+    test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
+    # the contents of git repos has changed over time, so only look for the top
+    test_dirs.add(os.path.join(temp_dir, '.git'))
+    # import pdb; pdb.set_trace()
+    assert test_dirs.issubset(dir_entries)
 
     # test --no-git-repo
     temp_dir = tmpdir.mkdir("test_init_no_git_dir")
@@ -50,15 +39,7 @@ def test_init(tmpdir):
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
-    test_dirs = {
-    temp_dir,
-    os.path.join(temp_dir, 'generated'),
-    os.path.join(temp_dir, 'template-patches'),
-    os.path.join(temp_dir, 'config'),
-    os.path.join(temp_dir, 'config/languages'),
-    os.path.join(temp_dir, 'downstream-templates'),
-    os.path.join(temp_dir, 'spec'),
-    os.path.join(temp_dir, 'spec/v1'),
-    os.path.join(temp_dir, 'templates')
-        }
+    # create a set of expected directory names to test against, and add the root temp_dir since it's in the output of `os.walk()`
+    test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
+    test_dirs.add(temp_dir)
     assert dir_entries == test_dirs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,50 @@
+import json
+import os
+import tempfile
+
+import flexmock
+import pytest
+
+from apigentools.commands.init import InitCommand
+# in case I need this later
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+    'fixtures',)
+
+def test_init():
+    original_dir = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            #sets do not presume the output of os.walk() will be ordered
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            # the layout of git repos has changed over time, this dir may or may not be present
+            if "./.git/branches" in dir_entries:
+                dir_entries.remove("./.git/branches")
+            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates', './.git', './.git/objects', './.git/objects/pack', './.git/objects/info', './.git/info', './.git/hooks', './.git/refs', './.git/refs/heads', './.git/refs/tags'}
+
+        # move back to original dir since tempdir is deleted on exiting with block
+    except Exception as e:
+        raise e
+    finally:
+        os.chdir(original_dir)
+
+    #test --no-git-repo
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
+            cmd_instance = InitCommand({}, args)
+            cmd_instance.run()
+            dir_entries = set(dir_entry[0] for dir_entry in os.walk("."))
+            assert dir_entries == {'.', './generated', './template-patches', './config', './config/languages', './downstream-templates', './spec', './spec/v1', './templates'}
+    except Exception as e:
+        raise e
+    finally:
+        os.chdir(original_dir)
+
+        #TODO - check that json in files is json and is correct
+
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,19 +6,17 @@ import pytest
 from apigentools.commands.init import InitCommand
 
 
-
-
 def test_init(tmpdir):
     # directories created by init command
     directory_names = {
-    'generated',
-    'template-patches',
-    'config',
-    os.path.join('config', 'languages'),
-    'downstream-templates',
-    'spec',
-    os.path.join('spec', 'v1'),
-    'templates',
+        'generated',
+        'template-patches',
+        'config',
+        os.path.join('config', 'languages'),
+        'downstream-templates',
+        'spec',
+        os.path.join('spec', 'v1'),
+        'templates',
     }
     temp_dir = tmpdir.mkdir("test_init_git_dir")
     args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
@@ -39,7 +37,8 @@ def test_init(tmpdir):
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
-    # create a set of expected directory names to test against, and add the root temp_dir since it's in the output of `os.walk()`
+    # create a set of expected directory names to test against, and add the
+    # root temp_dir since it's in the output of `os.walk()`
     test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
     test_dirs.add(temp_dir)
     assert dir_entries == test_dirs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from apigentools.commands.init import InitCommand
 
 def test_init(tmpdir):
     # directories created by init command
-    directory_names = {
+    DIRECTORY_NAMES = {
         'generated',
         'template-patches',
         'config',
@@ -18,16 +18,20 @@ def test_init(tmpdir):
         os.path.join('spec', 'v1'),
         'templates',
     }
+
     temp_dir = tmpdir.mkdir("test_init_git_dir")
     args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
+
     # sets do not presume the output of os.walk() will be ordered
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     # create a set of expected directory names to test against
-    test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
-    # the contents of git repos may change again
+    test_dirs = set(os.path.join(temp_dir, name) for name in DIRECTORY_NAMES)
+    # the directories created in git repos have changed in the past, so only
+    # checking for the root .git directory
     test_dirs.add(os.path.join(temp_dir, '.git'))
+
     assert test_dirs.issubset(dir_entries)
 
     # test --no-git-repo
@@ -35,9 +39,11 @@ def test_init(tmpdir):
     args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
+
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     # create a set of expected directory names to test against, and add the
     # root temp_dir since it's in the output of `os.walk()`
-    test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
+    test_dirs = set(os.path.join(temp_dir, name) for name in DIRECTORY_NAMES)
     test_dirs.add(temp_dir)
+
     assert dir_entries == test_dirs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,18 @@ import pytest
 
 from apigentools.commands.init import InitCommand
 
+temp_dir = "/temp_dir"
+TEST_DIRS = {
+    temp_dir,
+    os.path.join(temp_dir, 'generated'),
+    os.path.join(temp_dir, 'template-patches'),
+    os.path.join(temp_dir, 'config'),
+    os.path.join(temp_dir, 'config/languages'),
+    os.path.join(temp_dir, 'downstream-templates'),
+    os.path.join(temp_dir, 'spec'),
+    os.path.join(temp_dir, 'spec/v1'),
+    os.path.join(temp_dir, 'templates'),
+}
 
 def test_init(tmpdir):
     temp_dir = tmpdir.mkdir("test_init_git_dir")
@@ -15,20 +27,22 @@ def test_init(tmpdir):
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     # the layout of git repos has changed over time, so only look for the top
     # .git directory
-    test_dirs = {
-    temp_dir,
-    os.path.join(temp_dir, 'generated'),
-    os.path.join(temp_dir, 'template-patches'),
-    os.path.join(temp_dir, 'config'),
-    os.path.join(temp_dir, 'config/languages'),
-    os.path.join(temp_dir, 'downstream-templates'),
-    os.path.join(temp_dir, 'spec'),
-    os.path.join(temp_dir, 'spec/v1'),
-    os.path.join(temp_dir, 'templates'),
-    os.path.join(temp_dir, '.git'),
-    }
+    # test_dirs = {
+    # temp_dir,
+    # os.path.join(temp_dir, 'generated'),
+    # os.path.join(temp_dir, 'template-patches'),
+    # os.path.join(temp_dir, 'config'),
+    # os.path.join(temp_dir, 'config/languages'),
+    # os.path.join(temp_dir, 'downstream-templates'),
+    # os.path.join(temp_dir, 'spec'),
+    # os.path.join(temp_dir, 'spec/v1'),
+    # os.path.join(temp_dir, 'templates'),
+    # os.path.join(temp_dir, '.git'),
+    # }
+    TEST_DIRS = TEST_DIRS.add(os.path.join(temp_dir, '.git'))
+    assert TEST_DIRS.issubset(dir_entries)
 
-    assert test_dirs.issubset(dir_entries)
+    # assert test_dirs.issubset(dir_entries)
 
     # test --no-git-repo
     temp_dir = tmpdir.mkdir("test_init_no_git_dir")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,9 +26,8 @@ def test_init(tmpdir):
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     # create a set of expected directory names to test against
     test_dirs = set(os.path.join(temp_dir, name) for name in directory_names)
-    # the contents of git repos has changed over time, so only look for the top
+    # the contents of git repos may change again
     test_dirs.add(os.path.join(temp_dir, '.git'))
-    # import pdb; pdb.set_trace()
     assert test_dirs.issubset(dir_entries)
 
     # test --no-git-repo

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,29 +5,46 @@ import pytest
 
 from apigentools.commands.init import InitCommand
 
+
 def test_init(tmpdir):
-    original_dir = os.getcwd()
     temp_dir = tmpdir.mkdir("test_init_git_dir")
     args = flexmock.flexmock(no_git_repo=False, projectdir=temp_dir)
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
-    #sets do not presume the output of os.walk() will be ordered
+    # sets do not presume the output of os.walk() will be ordered
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
-    # the layout of git repos has changed over time, so only look for the top .git directory
+    # the layout of git repos has changed over time, so only look for the top
+    # .git directory
     test_dirs = {
-        os.path.join(temp_dir,'generated'), os.path.join(temp_dir,'template-patches'), os.path.join(temp_dir,'config'),
-        os.path.join(temp_dir,'config/languages'), os.path.join(temp_dir,'downstream-templates'),
-        os.path.join(temp_dir,'spec'), os.path.join(temp_dir,'spec/v1'), os.path.join(temp_dir,'templates'), os.path.join(temp_dir,'.git')}
+        temp_dir,
+        os.path.join(temp_dir, 'generated'),
+        os.path.join(temp_dir, 'template-patches'),
+        os.path.join(temp_dir, 'config'),
+        os.path.join(temp_dir, 'config/languages'),
+        os.path.join(temp_dir, 'downstream-templates'),
+        os.path.join(temp_dir, 'spec'),
+        os.path.join(temp_dir, 'spec/v1'),
+        os.path.join(temp_dir, 'templates'),
+        os.path.join(temp_dir, '.git'),
+        }
+
     assert test_dirs.issubset(dir_entries)
 
-    #test --no-git-repo
+    # test --no-git-repo
     temp_dir = tmpdir.mkdir("test_init_no_git_dir")
     args = flexmock.flexmock(no_git_repo=True, projectdir=temp_dir)
     cmd_instance = InitCommand({}, args)
     cmd_instance.run()
     dir_entries = set(dir_entry[0] for dir_entry in os.walk(temp_dir))
     test_dirs = {
-        os.path.join(temp_dir,'generated'), os.path.join(temp_dir,'template-patches'), os.path.join(temp_dir,'config'),
-        os.path.join(temp_dir,'config/languages'), os.path.join(temp_dir,'downstream-templates'), temp_dir,
-        os.path.join(temp_dir,'spec'), os.path.join(temp_dir,'spec/v1'), os.path.join(temp_dir,'templates')}
+        temp_dir,
+        os.path.join(temp_dir, 'generated'),
+        os.path.join(temp_dir, 'template-patches'),
+        os.path.join(temp_dir, 'config'),
+        os.path.join(temp_dir, 'config/languages'),
+        os.path.join(temp_dir, 'downstream-templates'),
+        os.path.join(temp_dir, 'spec'),
+        os.path.join(temp_dir, 'spec/v1'),
+        os.path.join(temp_dir, 'templates')
+        }
     assert dir_entries == test_dirs


### PR DESCRIPTION
### What does this PR do?

This PR refactors the InitCommand class to allow the contents of the JSON and .gitignore files to be imported for tests. I also changed the contents of the .gitignore file into a list of strings, so that it would be more readable. 

### Motivation

I wanted to validate that the JSON and .gitignore files were being written correctly, but as the class was initially written, I couldn't import the contents of the JSON files in order to use them in tests. 

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
