### PR TITLE
Switch from stdlib tmpdir to pytest fixture

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import os
 import subprocess
-import tempfile
 
 import flexmock
 import pytest
@@ -65,19 +64,19 @@ def test_run_command(caplog):
     assert secret not in caplog.text
     assert REDACTED_OUT_SECRET in caplog.text
 
-def test_change_cwd():
+def test_change_cwd(tmpdir):
     present_dir = os.getcwd()
-    with tempfile.TemporaryDirectory() as target_dir:
-        with change_cwd(target_dir):
-            assert os.getcwd() == os.path.realpath(target_dir)
-        assert os.getcwd() == present_dir
+    target_dir = tmpdir.mkdir("target_dir")
+    with change_cwd(target_dir):
+        assert os.getcwd() == os.path.realpath(target_dir)
+    assert os.getcwd() == present_dir
 
-def test_get_current_commit(caplog):
+def test_get_current_commit(caplog, tmpdir):
     with caplog.at_level(logging.WARNING):
-        with tempfile.TemporaryDirectory() as target_dir:
-            get_current_commit(target_dir)
-            for record in caplog.records:
-                assert "Failed getting current git commit" in record
+        target_dir = tmpdir.mkdir("target_dir")
+        get_current_commit(target_dir)
+        for record in caplog.records:
+            assert "Failed getting current git commit" in record
     flexmock(subprocess).should_receive("run").and_return(subprocess.CompletedProcess(1, 0, "some_hash"))
     assert get_current_commit(".") == "some_hash"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,8 @@ def test_get_current_commit(caplog, tmpdir):
         get_current_commit(target_dir)
         for record in caplog.records:
             assert "Failed getting current git commit" in record
-    flexmock(subprocess).should_receive("run").and_return(subprocess.CompletedProcess(1, 0, "some_hash"))
+    flexmock(subprocess).should_receive("run").\
+        and_return(subprocess.CompletedProcess(1, 0, "some_hash"))
     assert get_current_commit(".") == "some_hash"
 
 def test_validate_duplicates():


### PR DESCRIPTION
### What does this PR do?

Replaces the tempfile module from the stdlib with the Pytest tmpdir fixture

### Motivation

Slavek asked me to use the [tmpdir](http://doc.pytest.org/en/latest/tmpdir.html#the-tmpdir-fixture) fixture instead of tempfile in [this pr](https://github.com/DataDog/apigentools/pull/77) and we decided to use the tmpdir fixture across all the tests. 

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
