### PR TITLE
Fix test image name

### DIFF
--- a/apigentools/commands/test.py
+++ b/apigentools/commands/test.py
@@ -23,6 +23,11 @@ class TestCommand(Command):
             fname,
         )
 
+    def get_test_image_name(self, lang, version):
+        if version is None:
+            return f"apigentools-test-{lang}"
+        return f"apigentools-test-{lang}-{version}"
+
     def build_test_image(self, df_path, img_name):
         if os.path.exists(df_path):
             build = [
@@ -69,9 +74,7 @@ class TestCommand(Command):
                 if version is not None and version not in versions:
                     continue
                 df_path = self.get_test_df_name(lang_name, version)
-                img_name = "apigentools-test-{lang}-{version}".format(
-                    lang=lang_name, version=version
-                )
+                img_name = self.get_test_image_name(lang_name, version)
                 log.info(
                     "Looking up %s to test language %s, %s",
                     df_path, lang_name, spec_version_loggable


### PR DESCRIPTION
### What does this PR do?

Fixes generation of test image name.

### Motivation

One can run tests using `Dockerfile.test` or `Dockerfile.test.vX`. The first option was however broken.

### Additional Notes

We should revert hotfix in our generated Java client.

### Review checklist (to be filled by reviewers)

- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
