### PR TITLE
Make server_base_urls optional

### DIFF
--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -19,7 +19,6 @@ class InitCommand(Command):
     CONFIG_FILE_JSON = {
         "codegen_exec": "openapi-generator",
         "languages": {},
-        "server_base_urls": {"v1": "https://api.myserver.com/v1"},
         "spec_sections": {"v1": []},
         "spec_versions": ["v1"],
     }

--- a/apigentools/commands/init.py
+++ b/apigentools/commands/init.py
@@ -30,6 +30,7 @@ class InitCommand(Command):
             "version": "1.0",
         },
         "openapi": "3.0.0",
+        "servers": [{"url": "https://api.example.com/v1"}],
     }
     V1_SHARED_JSON = {
         "components": {

--- a/apigentools/utils.py
+++ b/apigentools/utils.py
@@ -363,9 +363,11 @@ def write_full_spec(config, spec_dir, spec_version, spec_sections, full_spec_fil
             "links": {},
             "callbacks": {},
         },
-        "servers": [{"url": config.server_base_urls[spec_version]}],
         "security": [],
     }
+    if spec_version in config.server_base_urls:
+        # Servers should be defined in header.yaml or endpoints
+        full_spec["servers"] = [{"url": config.server_base_urls[spec_version]}]
 
     for filename in filenames:
         fpath = os.path.join(spec_version_dir, filename)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [Improvement] Make `server_base_url` optional and possibly deprecated in the future version.
+
 ## 0.9.0
 
 * [Feature] Allow using specific branch as base for generation

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ One of the apigentools core ideas is being able to generate clients that can acc
 
 Since OpenAPI specification files can grow very large, apigentools allow you to split them into multiple "sections". Initially, only two files are created. These are also files that are expected to exist for each major version of your API:
 
-* `spec/v1/header.yaml` - A header file that should only contain the OpenAPI keys `openapi`, `info`, and `externalDocs` (note that apigentools fills in `servers` dynamically based on your `config/config.yaml`).
+* `spec/v1/header.yaml` - A header file that should only contain the OpenAPI keys `openapi`, `info`, `externalDocs` and `servers` (note that apigentools can fill in `servers` dynamically based on your `config/config.yaml`).
 * `spec/v1/shared.yaml` - A file containing any OpenAPI objects that are referenced from more than one "section"—`components` (which includes `schemas` and `security_schemes`), `security`, and `tags`.
 
 Add a file `spec/v1/users.yaml` with the following content:
@@ -106,9 +106,6 @@ Now you just need to add the `users.yaml` spec section to `config/config.json`. 
 {
     "codegen_exec": "openapi-generator",
     "languages": {},
-    "server_base_urls": {
-        "v1": "https://api.myserver.com/v1"
-    },
     "spec_sections": {
         "v1": ["users.yaml"]
     },
@@ -144,9 +141,6 @@ Configure apigentools to actually generate code for one language. Try doing this
             "spec_versions": ["v1"],
             "version_path_template": "myapi_{{spec_version}}"
         }
-    },
-    "server_base_urls": {
-        "v1": "https://api.myserver.com/v1"
     },
     "spec_sections": {
         "v1": ["users.yaml"]

--- a/docs/spec_repo.md
+++ b/docs/spec_repo.md
@@ -93,9 +93,6 @@ Example:
             "generate_extra_args": ["--skip-overwrite", "--generate-model-as-alias"]
         }
     },
-    "server_base_urls": {
-        "v1": "https://api.myserver.com/v1"
-    },
     "spec_sections": {
         "v1": ["accounts.yaml", "users.yaml"],
         "v2": ["users.yaml"]


### PR DESCRIPTION
### What does this PR do?

Makes `server_base_urls` optional.

### Motivation

Servers can be configured as templates in OpenAPI spec both globaly (in `header.yaml`) or per endpoint. This change makes custom generation of `servers.0.url` optional.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
