### PR TITLE
Use image from config when not supplied

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -131,6 +131,10 @@ class GenerateCommand(Command):
         """
         image = self.args.generated_with_image
 
+        if image is None:
+            # TODO add check that it is running in container
+            image = self.config.container_apigentools_image
+
         if image is not None and image.endswith(":latest"):
             hash_file = os.environ.get(
                 "_APIGENTOOLS_GIT_HASH_FILE", "/var/lib/apigentools/git-hash"


### PR DESCRIPTION
### What does this PR do?

Uses image name from `config.json`.

### Motivation

The image can be defined in the configuration instead of an option, but the `.apigentool-info` was not correctly updated.

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
