### PR TITLE
Always pass APIGENTOOLS_IMAGE env to the container

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -131,10 +131,6 @@ class GenerateCommand(Command):
         """
         image = self.args.generated_with_image
 
-        if image is None:
-            # TODO add check that it is running in container
-            image = self.config.container_apigentools_image
-
         if image is not None and image.endswith(":latest"):
             hash_file = os.environ.get(
                 "_APIGENTOOLS_GIT_HASH_FILE", "/var/lib/apigentools/git-hash"

--- a/apigentools/container_cli.py
+++ b/apigentools/container_cli.py
@@ -72,8 +72,11 @@ def container_cli():
     command.append('GIT_SSH_COMMAND=ssh -o "IgnoreUnknown *"')
     for k, v in os.environ.items():
         if k.startswith("APIGENTOOLS_"):
+            if k == "APIGENTOOLS_IMAGE":
+                pass
             command.append("-e")
             command.append("{}={}".format(k, v))
+    command.extend(["-e", "APIGENTOOLS_IMAGE={}".format(image)])
 
     for mountdir, mountopts in mountpoints.items():
         command.append("-v")


### PR DESCRIPTION
### What does this PR do?

Makes sure we always pass `APIGENTOOLS_IMAGE` env var to container to ensure that the logic constructing `.apigentools-info` can properly record it (this fixes regression introduced by rewriting the shell script to Python entrypoint).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
