### PR TITLE
Make ssh in container ignore UseKeychain option

### DIFF
--- a/apigentools/container_cli.py
+++ b/apigentools/container_cli.py
@@ -66,6 +66,10 @@ def container_cli():
     }
 
     command = ["docker", "run", "--rm"]
+    # Some people on MacOS use `UseKeychain` option not recognized by linux ssh
+    # so make sure we ignore it
+    command.append("-e")
+    command.append('GIT_SSH_COMMAND=ssh -o "IgnoreUnknown *"')
     for k, v in os.environ.items():
         if k.startswith("APIGENTOOLS_"):
             command.append("-e")


### PR DESCRIPTION
### What does this PR do?

This makes SSH work in container even if there's a Mac-specific `UseKeychain` option used in ssh config.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
