### PR TITLE
install openapi-generator in CI

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -25,5 +25,7 @@ jobs:
         versionSpec: $(PYTHON_VERSION)
     - script: pip install -e .[tests]
       displayName: Install test dependencies
+    - script: sudo npm install -g @openapitools/openapi-generator-cli
+      displayName: Install openapi-generator
     - script: pytest
       displayName: Run the test via Pytest


### PR DESCRIPTION
### What does this PR do?

Installs openapi-gentools in the CI pipeline. 

To install npm packages with the `-g` flag, on Linux-based Azure CI pipelines, it's necessary to use `sudo`: 

https://github.com/MicrosoftDocs/vsts-docs/issues/2570

https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/javascript?view=azure-devops&tabs=yaml#install-tools-on-your-build-agent

### Motivation

Tests that depended on openapi-gentools were failing 

### Additional Notes

This is the same PR as https://github.com/DataDog/apigentools/pull/94, but with a cleaner git history. 


### Review checklist (to be filled by reviewers)

- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/apigentools/blob/master/CONTRIBUTING.md#commit-messages)
