### PR TITLE
Fix file name conflict

### DIFF
--- a/apigentools/commands/command.py
+++ b/apigentools/commands/command.py
@@ -33,13 +33,15 @@ class Command(abc.ABC):
             language_config = self.config.get_language_config(language)
             versions = set(language_config.spec_versions or self.config.spec_versions)
             for version in versions & allowed_versions:
+                spec_version_dir = os.path.join(self.args.spec_dir, version)
                 suffix = (
                     language
                     if language_config.spec_sections != self.config.spec_sections
                     else None
                 )
-                yield language, version, get_full_spec_file_name(
-                    self.args.full_spec_file, suffix
+                yield language, version, os.path.join(
+                    spec_version_dir,
+                    get_full_spec_file_name(self.args.full_spec_file, suffix),
                 )
 
     def get_generated_lang_dir(self, lang):

--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -213,9 +213,10 @@ class GenerateCommand(Command):
 
         # first, generate full spec for all major versions of the API
         for language, version, fs_file in self.yield_lang_version_specfile():
-            info[language][version] = os.path.join(self.args.spec_dir, version, fs_file)
+            info[language][version] = fs_file
 
             if fs_file in fs_files:
+                log.info(f"Reuse {fs_file} for {language} and {version}")
                 continue
             fs_files.add(fs_file)
 
@@ -227,6 +228,7 @@ class GenerateCommand(Command):
                 self.config.get_language_config(language).spec_sections,
                 fs_file,
             )
+            log.info(f"Generated {fs_file} for {language} and {version}")
 
         pull_repo = self.args.clone_repo
 

--- a/apigentools/utils.py
+++ b/apigentools/utils.py
@@ -284,7 +284,7 @@ def get_full_spec_file_name(default_fsf, l):
     return "{}.{}".format(default_fsf, l)
 
 
-def write_full_spec(config, spec_dir, spec_version, spec_sections, full_spec_file):
+def write_full_spec(config, spec_dir, spec_version, spec_sections, fs_path):
     """ Write a full OpenAPI spec file
 
     :param config: apigentools config
@@ -296,13 +296,12 @@ def write_full_spec(config, spec_dir, spec_version, spec_sections, full_spec_fil
     :type spec_version: ``str``
     :param spec_sections: List of spec sections to combine
     :type spec_sections: ``list`` of ``str``
-    :param full_spec_file: Name of the output file for the combined OpenAPI spec
+    :param full_spec_file: Full path of the output file for the combined OpenAPI spec
     :type full_spec_file: ``str``
     :return: Path to the written combined OpenAPI spec file
     :rtype: ``str``
     """
     spec_version_dir = os.path.join(spec_dir, spec_version)
-    fs_path = os.path.join(spec_version_dir, full_spec_file)
 
     filenames = spec_sections[spec_version] + [
         SHARED_SECTION_NAME + ".yaml",


### PR DESCRIPTION
### What does this PR do?

Fixes problem with spec file generation by returning full path.

### Description of the Change

Generates and uses full path for generated OpenAPI spec files.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

This is a first step to allow moving `full_spec*.yaml` files to different location e.g. `generated` folder.

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
