### PR TITLE
Update name of template output dir flag

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -83,7 +83,7 @@ TEMPLATE_PATCHES_DIR_ARG = (
     },
 )
 TEMPLATES_OUTPUT_DIR_ARG = (
-    ("-to", "--templates-output-dir"),
+    ("-T", "--templates-output-dir"),
     {
         "default": env_or_val(
             "APIGENTOOLS_TEMPLATES_DIR", constants.DEFAULT_TEMPLATES_DIR

--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -83,7 +83,7 @@ TEMPLATE_PATCHES_DIR_ARG = (
     },
 )
 TEMPLATES_OUTPUT_DIR_ARG = (
-    ("-o", "--output-dir"),
+    ("-to", "--templates-output-dir"),
     {
         "default": env_or_val(
             "APIGENTOOLS_TEMPLATES_DIR", constants.DEFAULT_TEMPLATES_DIR

--- a/apigentools/commands/templates.py
+++ b/apigentools/commands/templates.py
@@ -90,7 +90,7 @@ class TemplatesCommand(Command):
                 upstream_templatedir = self.config.get_language_config(
                     lang
                 ).upstream_templates_dir
-                outlang_dir = os.path.join(self.args.output_dir, lang)
+                outlang_dir = os.path.join(self.args.templates_output_dir, lang)
                 if os.path.exists(outlang_dir):
                     shutil.rmtree(outlang_dir)
                 shutil.copytree(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,7 +74,7 @@ Since version 0.10.0, apigentools also supports processing templates (equivalent
 Argument | Description | Environment Variable | Default
 ---------|-------------|----------------------|--------
 `--templates-source {local-dir,openapi-git,openapi-jar,skip}` | Source to use for obtaining templates to be processed (`skip` to not process templates) | `APIGENTOOLS_TEMPLATES_SOURCE`| `skip`
-`-o OUTPUT_DIR, --output-dir OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
+`-to TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
 `-p TEMPLATE_PATCHES_DIR, --template-patches-dir TEMPLATE_PATCHES_DIR` | Directory with patches for upstream templates. | `APIGENTOOLS_TEMPLATE_PATCHES_DIR` | `template-patches`
 `--jar-path` | Path to `openapi-generator` JAR file (use if `--templates-source=openapi-jar`). | `APIGENTOOLS_OPENAPI_JAR` | `openapi-generator.jar`
 `--local-path LOCAL_PATH` | Path to directory with `openapi-generator` upstream templates (use if `--templates-source=local-dir`)
@@ -124,7 +124,7 @@ Obtains upstream `openapi-generator` templates, applies template patches, and sa
 Argument | Description | Environment Variable | Default
 ---------|-------------|----------------------|--------
 `-h, --help` | Show help message and exit.
-`-o OUTPUT_DIR, --output-dir OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
+`-to TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
 `-p TEMPLATE_PATCHES_DIR, --template-patches-dir TEMPLATE_PATCHES_DIR` | Directory with patches for upstream templates. | `APIGENTOOLS_TEMPLATE_PATCHES_DIR` | `template-patches`
 
 ### `apigentools templates local-dir`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,7 +74,7 @@ Since version 0.10.0, apigentools also supports processing templates (equivalent
 Argument | Description | Environment Variable | Default
 ---------|-------------|----------------------|--------
 `--templates-source {local-dir,openapi-git,openapi-jar,skip}` | Source to use for obtaining templates to be processed (`skip` to not process templates) | `APIGENTOOLS_TEMPLATES_SOURCE`| `skip`
-`-to TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
+`-T TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
 `-p TEMPLATE_PATCHES_DIR, --template-patches-dir TEMPLATE_PATCHES_DIR` | Directory with patches for upstream templates. | `APIGENTOOLS_TEMPLATE_PATCHES_DIR` | `template-patches`
 `--jar-path` | Path to `openapi-generator` JAR file (use if `--templates-source=openapi-jar`). | `APIGENTOOLS_OPENAPI_JAR` | `openapi-generator.jar`
 `--local-path LOCAL_PATH` | Path to directory with `openapi-generator` upstream templates (use if `--templates-source=local-dir`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,7 +124,7 @@ Obtains upstream `openapi-generator` templates, applies template patches, and sa
 Argument | Description | Environment Variable | Default
 ---------|-------------|----------------------|--------
 `-h, --help` | Show help message and exit.
-`-to TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
+`-T TEMPLATES_OUTPUT_DIR, --templates-output-dir TEMPLATES_OUTPUT_DIR` | Path to directory where processed upstream templates are saved. | `APIGENTOOLS_TEMPLATES_DIR` | `templates`
 `-p TEMPLATE_PATCHES_DIR, --template-patches-dir TEMPLATE_PATCHES_DIR` | Directory with patches for upstream templates. | `APIGENTOOLS_TEMPLATE_PATCHES_DIR` | `template-patches`
 
 ### `apigentools templates local-dir`


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Update the name of the output-dir flag to more explicitly note that it'll be the output directory of the generated templates, not the output directory of the generate command. 

### Description of the Change

The name of this flag was confusing me, especially when passing it into the generate command. The `output-dir` to me, meant the output directory of the generation step, not the templates. 

Changing this name makes that much more clear. 

### Possible Drawbacks

This will require any users of the existing flag to update to the new flag name. However, when using `container-apigentools` there are defaults that don't require these flags, so they shouldn't be currently relied on too much. 

### Verification Process

I ran apigentools generate locally with this new flag and confirmed the directory I passed in contained the pulled down templates. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
