### PR TITLE
Fix template generation during generate command

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -14,7 +14,7 @@ import click
 
 from apigentools import __version__, constants
 from apigentools.commands.command import Command
-from apigentools.commands.templates import templates
+from apigentools.commands.templates import TemplatesCommand
 from apigentools.config import Config
 from apigentools.constants import GITHUB_REPO_URL_TEMPLATE, LANGUAGE_OAPI_CONFIGS
 from apigentools.utils import (
@@ -351,8 +351,12 @@ class GenerateCommand(Command):
         if self.args.get("templates_source") == constants.TEMPLATES_SOURCE_SKIP:
             log.info("Skipping templates processing")
         else:
-            ctx = click.get_current_context()
-            ctx.forward(templates, self.args)
+            log.info("Generating templates")
+            template_cmd = TemplatesCommand({}, self.args)
+            template_cmd.config = Config.from_file(
+                os.path.join(self.args.get("config_dir"), constants.DEFAULT_CONFIG_FILE)
+            )
+            template_cmd.run()
 
         info = collections.defaultdict(dict)
         fs_files = set()

--- a/apigentools/commands/templates.py
+++ b/apigentools/commands/templates.py
@@ -100,7 +100,7 @@ class TemplatesCommand(Command):
             log.info("Obtaining upstream templates ...")
             patch_in = copy_from = td
             if self.args.get("templates_source") == "openapi-jar":
-                run_command(["unzip", "-q", self.args.get("repo_url"), "-d", td])
+                run_command(["unzip", "-q", self.args.get("jar_path"), "-d", td])
             elif self.args.get("templates_source") == "local-dir":
                 for lang in self.config.languages:
                     lang_upstream_templates_dir = self.config.get_language_config(


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

This PR fixes two issues with the template command when being called from the generate command (most commonly when using container-apigentools)

First fix is that the config argument looking for the jar path when using the templates from the openapi-jar was incorrect. This resolves that. 

The second issue was with using click.invoke to call the template command. The way the template command is broken up is via a main template command, and three subcommands. Since there doesn't appear to be a way to execute a subcommand, this was just failing silently. Instead, we now create an instance of the TemplateCommand class and execute it directly from the Generate command. 

I verified this seems to work as expected by building the container image locally and running `container-apigentools generate` and seeing the templates get generated. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
