### PR TITLE
Make it possible to provide different operations for the same path in different files

### DIFF
--- a/apigentools/utils.py
+++ b/apigentools/utils.py
@@ -296,8 +296,8 @@ def write_full_spec(config, spec_dir, spec_version, spec_sections, fs_path):
     :type spec_version: ``str``
     :param spec_sections: List of spec sections to combine
     :type spec_sections: ``list`` of ``str``
-    :param full_spec_file: Full path of the output file for the combined OpenAPI spec
-    :type full_spec_file: ``str``
+    :param fs_path: Full path of the output file for the combined OpenAPI spec
+    :type fs_path: ``str``
     :return: Path to the written combined OpenAPI spec file
     :rtype: ``str``
     """
@@ -336,8 +336,10 @@ def write_full_spec(config, spec_dir, spec_version, spec_sections, fs_path):
             if filename == HEADER_FILE_NAME:
                 full_spec.update(loaded)
             else:
-                validate_duplicates(loaded.get("paths", {}), full_spec["paths"].keys())
-                full_spec["paths"].update(loaded.get("paths", {}))
+                for k, v in loaded.get("paths", {}).items():
+                    full_spec["paths"].setdefault(k, {})
+                    validate_duplicates(v, full_spec["paths"][k])
+                    full_spec["paths"][k].update(v)
 
                 validate_duplicates(loaded.get("tags", []), full_spec.get("tags", []))
                 full_spec["tags"].extend(loaded.get("tags", []))


### PR DESCRIPTION
### What does this PR do?

Adds the possibility of putting to different operations (e.g. `get` vs `put`) for the same path in two different spec files to then be merged.

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
