### PR TITLE
Make generate command stop and ask for passphrase when SSH key is protected by it

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -509,11 +509,17 @@ class GenerateCommand(Command):
                 else repo
             )
             log.info("Pulling repository %s", log_repo)
-            if not self.__ssh_will_ask_passphrase_logged and not self.args.get("git_via_https"):
+            if not self.__ssh_will_ask_passphrase_logged and not self.args.get(
+                "git_via_https"
+            ):
                 self.__ssh_will_ask_passphrase_logged = True
-                log.info("If your SSH key is protected by passphrase, you'll be asked for it.")
+                log.info(
+                    "If your SSH key is protected by passphrase, you'll be asked for it."
+                )
                 if self.get_image_name() is not None:
-                    log.info("Note that your SSH keys are mounted under /root/.ssh/ in the container.")
+                    log.info(
+                        "Note that your SSH keys are mounted under /root/.ssh/ in the container."
+                    )
             run_command(
                 [
                     "git",

--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -183,6 +183,7 @@ def generate(ctx, **kwargs):
 
 class GenerateCommand(Command):
     __cached_codegen_version = None
+    __ssh_will_ask_passphrase_logged = False
 
     def run_language_commands(self, language, phase, cwd, chevron_vars=None):
         """ Runs commands specified in language settings for given language and phase
@@ -348,6 +349,7 @@ class GenerateCommand(Command):
         return missing
 
     def run(self):
+        self.__ssh_will_ask_passphrase_logged = False
         if self.args.get("templates_source") == constants.TEMPLATES_SOURCE_SKIP:
             log.info("Skipping templates processing")
         else:
@@ -507,6 +509,11 @@ class GenerateCommand(Command):
                 else repo
             )
             log.info("Pulling repository %s", log_repo)
+            if not self.__ssh_will_ask_passphrase_logged and not self.args.get("git_via_https"):
+                self.__ssh_will_ask_passphrase_logged = True
+                log.info("If your SSH key is protected by passphrase, you'll be asked for it.")
+                if self.get_image_name() is not None:
+                    log.info("Note that your SSH keys are mounted under /root/.ssh/ in the container.")
             run_command(
                 [
                     "git",

--- a/apigentools/container_cli.py
+++ b/apigentools/container_cli.py
@@ -66,7 +66,8 @@ def container_cli():
         os.path.expanduser("~/.ssh"): ("/root/.ssh/", "ro"),
     }
 
-    command = ["docker", "run", "--rm"]
+    # we add "-ti" so that git cloning can stop and ask for passphrase for keys if necessary
+    command = ["docker", "run", "-ti", "--rm"]
     # Some people on MacOS use `UseKeychain` option not recognized by linux ssh
     # so make sure we ignore it
     command.append("-e")


### PR DESCRIPTION
### What does this PR do?

It adds `-ti` as arguments to `docker run` inside `container-apigentools`. This means that when cloning repos via GIT+SSH, SSH will be able to ask user for passphrase when necessary.

As it only needs to ask for the first time, we only log the information about this on the first clone.

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
