### PR TITLE
Use new method for getting dir

### DIFF
--- a/apigentools/commands/generate.py
+++ b/apigentools/commands/generate.py
@@ -275,7 +275,7 @@ class GenerateCommand(Command):
                 self.pull_repository(language_config, branch=self.args.get("branch"))
 
             if self.args.get("delete_generated_files"):
-                self.remove_generated_files(language)
+                self.remove_generated_files(language_config)
 
             for version, input_spec in versions.items():
                 if self.args.get("skip_templates"):
@@ -400,14 +400,14 @@ class GenerateCommand(Command):
                     )
                     raise
 
-    def remove_generated_files(self, language):
+    def remove_generated_files(self, language_config):
         """
         Remove all generated files from the generate output directory
         Files are deemed as "generated" if they match any regex in the .generated_files file
         at the root of the output repository.
         """
         blacklist_regexes = set()
-        output_dir = os.path.abspath(self.get_generated_lang_dir(language))
+        output_dir = os.path.abspath(language_config.generated_lang_dir)
         blacklist_file = os.path.join(output_dir, GENERATION_BLACKLIST_FILENAME)
 
         log.info(f"Removing generated files from the output directory: {output_dir}")


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The migration to apigentools 1.0.0 reworked the `get_generated_lang_dir` method. This PR updates the remove generated files method to use the new method. 


### Verification Process
Working on this feature locally and got an exception, this fix works locally. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
