### PR TITLE
Fix inheritance of container_opts for inherited commands

### DIFF
--- a/tests/unit/fixtures/good_config_yaml.yaml
+++ b/tests/unit/fixtures/good_config_yaml.yaml
@@ -34,6 +34,16 @@ languages:
             jar_path: /some/path.jar
             templates_dir: Java
             type: openapi-jar
+        tests:
+          - commandline:
+            - echo
+            - "1"
+          - commandline:
+            - echo
+            - "1"
+            container_opts:
+              environment:
+                LEVEL: "3"
       v1:
         commands:
           - commandline:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -47,6 +47,16 @@ config_sample = {
                             "description": "Some post command",
                         },
                     ],
+                    # NOTE: the scenario here is that the tests must not be defined in v1,
+                    # but must be defined in default; then we check that container_opts
+                    # were properly inherited from v1 and not from default
+                    "tests": [
+                        {"commandline": ["echo", "1"]},
+                        {
+                            "container_opts": {"environment": {"LEVEL": "3"}},
+                            "commandline": ["echo", "1"],
+                        },
+                    ],
                 },
                 "v1": {
                     "container_opts": {
@@ -135,6 +145,23 @@ def check_config(c):
     assert java.commands_for("v2")[0].container_opts == {
         "environment": {"JAVA": "y", "DEFAULT": "y", "CMD": "y", "LEVEL": "3"},
         "image": "java:image",
+        "inherit": True,
+        "system": False,
+        "workdir": ".",
+    }
+
+    # make sure that container_opts are inherited properly when commands are defined
+    # on "default" generation, but container_opts are overriden on a specific version
+    assert java.test_commands_for("v1")[0].container_opts == {
+        "environment": {"LEVEL": "2", "V1": "y"},
+        "image": "other:image",
+        "inherit": False,
+        "system": False,
+        "workdir": ".",
+    }
+    assert java.test_commands_for("v1")[1].container_opts == {
+        "environment": {"LEVEL": "3", "V1": "y"},
+        "image": "other:image",
         "inherit": True,
         "system": False,
         "workdir": ".",


### PR DESCRIPTION
### What does this PR do?

This fixes situation when commands are defined on `default` generation, but `container_opts` are overriden for a specific version - with this fix, the `container_opts` for commands will be inherited from the specific version, not from `default`.

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
