### PR TITLE
Bump pydantic dep to 1.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     jsonpath-ng==1.5.1
     PyYAML==5.3.1
     packaging==20.3
-    pydantic @ git+ssh://git@github.com/samuelcolvin/pydantic@6b53cabe036a907a117e3530719befef2c417ae1#egg=some-pkg
+    pydantic==1.7
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     jsonpath-ng==1.5.1
     PyYAML==5.3.1
     packaging==20.3
-    pydantic==1.5
+    pydantic @ git+ssh://git@github.com/samuelcolvin/pydantic@6b53cabe036a907a117e3530719befef2c417ae1#egg=some-pkg
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm


### PR DESCRIPTION
Bumps the pydantic version from 1.5 -> 1.7
Most notably, this introduces support for python 3.9

Prior to this change, all apigentools commands run via Python 3.9 would fail with:

```
  File "/usr/local/Cellar/python@3.9/3.9.0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 648, in __getattr__
    raise AttributeError(attr)
AttributeError: __args__
```