### PR TITLE
Add support for docker run options in test command

### DIFF
--- a/apigentools/commands/command.py
+++ b/apigentools/commands/command.py
@@ -127,6 +127,7 @@ class Command(abc.ABC):
         chevron_vars=None,
         additional_functions=None,
         env_override=None,
+        docker_run_options=None,
     ):
         log.info("Running command '%s'", command.description)
 
@@ -201,6 +202,8 @@ class Command(abc.ABC):
                 dockerized.extend(["--entrypoint", to_run[0]])
             for k, v in additional_env.items():
                 dockerized.extend(["-e", "{}={}".format(k, v)])
+            if docker_run_options:
+                dockerized.extend(docker_run_options)
 
             dockerized.extend([image] + to_run[1:])
             to_run = dockerized

--- a/apigentools/commands/test.py
+++ b/apigentools/commands/test.py
@@ -4,6 +4,7 @@
 # Copyright 2019-Present Datadog, Inc.
 import logging
 import os
+import shlex
 import subprocess
 
 import click
@@ -33,6 +34,11 @@ log = logging.getLogger(__name__)
     + "it *will* be logged as part of the test output by apigentools).",
 )
 @click.option(
+    "--docker-run-options",
+    default=env_or_val("APIGENTOOLS_DOCKER_RUN_OPTIONS", None),
+    help="Additional options passed to `docker run` command.",
+)
+@click.option(
     "--no-sensitive-output",
     is_flag=True,
     default=env_or_val("APIGENTOOLS_NO_SENSITIVE_OUTPUT", False),
@@ -49,6 +55,7 @@ def test(ctx, **kwargs):
 class TestCommand(Command):
     def run(self):
         cmd_result = 0
+        docker_run_options = shlex.split(self.args.get("docker_run_options", ""))
 
         for lang_name, version in self.yield_lang_version():
             language_config = self.config.get_language_config(lang_name)
@@ -76,6 +83,7 @@ class TestCommand(Command):
                     language_config.generated_lang_version_dir_for(version),
                     language_config.chevron_vars_for(version),
                     env_override=env_override,
+                    docker_run_options=docker_run_options,
                 )
 
         return cmd_result


### PR DESCRIPTION
### What does this PR do?

Allows definition of custom `docker run` options for `apigentools test`. It is useful for attaching network or forwarding env variables.

### Description of the Change

`apigentools test --docker-run-options "--network=host"`
or `APIGENTOOLS_DOCKER_RUN_OPTIONS="--network=host" apigentools test`

### Alternate Designs

❓ 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
