### PR TITLE
Fix parsing of APIGENTOOLS_API_VERSION env variable

### DIFF
--- a/apigentools/cli.py
+++ b/apigentools/cli.py
@@ -68,7 +68,7 @@ log = logging.getLogger(__name__)
     "-av",
     "--api-versions",
     multiple=True,
-    default=env_or_val("APIGENTOOLS_API_VERSION", None),
+    default=env_or_val("APIGENTOOLS_API_VERSION", None, __type=list),
     help="The API version to run the specified action against."
     "These must match what the config in the spec repo contains."
     "Ex: 'apigentools -av v1 -av v2 test' (Default: None to run all)",


### PR DESCRIPTION
### What does this PR do?

Fixes parsing of `APIGENTOOLS_API_VERSION` environment variable. Currently, it would parse `v1` as `("v", "1")`.

### Description of the Change

Treats env value as `:` separated list.

### Alternate Designs

n/a

### Possible Drawbacks

n/a

### Verification Process

`APIGENTOOLS_API_VERSION=v1 apigentools config`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
