### PR TITLE
Update Dockerfile to be able to build arm64 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN /usr/local/bin/docker-entrypoint.sh version
 FROM fedora:35
 
 ENV OPENAPI_GENERATOR_VERSION=5.0.0-SNAPSHOT \
-    PACKAGES="docker findutils git golang-googlecode-tools-goimports java jq maven nodejs patch python3 python3-pip unzip"
+    PACKAGES="docker findutils git golang-x-tools-goimports java jq maven nodejs patch python3 python3-pip unzip"
 
 RUN dnf install -y gcc-c++ make && \
     curl -sL https://rpm.nodesource.com/setup_16.x | bash - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openapitools/openapi-generator-cli@sha256:bda9ca9b2d4ad50a41e1b2cdfbb84d7c2
 # Ensure the jar file is build
 RUN /usr/local/bin/docker-entrypoint.sh version
 
-FROM fedora:30
+FROM fedora:35
 
 ENV OPENAPI_GENERATOR_VERSION=5.0.0-SNAPSHOT \
     PACKAGES="docker findutils git golang-googlecode-tools-goimports java jq maven nodejs patch python3 python3-pip unzip"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV OPENAPI_GENERATOR_VERSION=5.0.0-SNAPSHOT \
     PACKAGES="docker findutils git golang-googlecode-tools-goimports java jq maven nodejs patch python3 python3-pip unzip"
 
 RUN dnf install -y gcc-c++ make && \
-    curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y ${PACKAGES} && \
     dnf clean all && \
     curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh > /usr/bin/openapi-generator && \


### PR DESCRIPTION
### What does this PR do?

I had trouble generating code on my M1 laptop while it was working on other chipsets. Since there is only an amd64 image available this PR should allow building an arm64 version too.

### Description of the Change

Update the `Dockerfile` such that it can be built for arm64 architectures (i.e. apple silicon).
1. Update nodejs to v16 (native arm64 binaries are available from this version on)
2. Update fedora to v35 (nodejs v16 is available from v32)
3. Rename `golang-googlecode-tools-goimports` to `golang-x-tools-goimports` (package has been renamed)

### Verification Process

I couldn't generate my project with the amd64 image available. After building locally with this updated Dockerfile, I can.

However, I couldn't verify it on amd64.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
