### PR TITLE
Rename integrations-tools-and-libraries to api-clients in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 *                       @DataDog/api-clients
 
 # Documentation
-*.md                    @DataDog/baklava @DataDog/api-clients
-LICENSE                 @DataDog/baklava @DataDog/api-clients
-LICENSE-3rdparty.csv    @DataDog/baklava @DataDog/api-clients
+*.md                    @DataDog/api-clients
+LICENSE                 @DataDog/api-clients
+LICENSE-3rdparty.csv    @DataDog/api-clients

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 *                       @DataDog/api-clients
 
 # Documentation
-*.md                    @DataDog/api-clients
-LICENSE                 @DataDog/api-clients
-LICENSE-3rdparty.csv    @DataDog/api-clients
+*.md                    @DataDog/baklava @DataDog/api-clients
+LICENSE                 @DataDog/baklava @DataDog/api-clients
+LICENSE-3rdparty.csv    @DataDog/baklava @DataDog/api-clients

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 *                       @DataDog/api-clients
 
 # Documentation
-*.md                    @DataDog/baklava @DataDog/api-clients
-LICENSE                 @DataDog/baklava @DataDog/api-clients
-LICENSE-3rdparty.csv    @DataDog/baklava @DataDog/api-clients
+*.md                    @DataDog/documentation @DataDog/api-clients
+LICENSE                 @DataDog/documentation @DataDog/api-clients
+LICENSE-3rdparty.csv    @DataDog/documentation @DataDog/api-clients

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,9 @@
 # and another team can own the rest of the directory.
 
 # All your base
-*                       @DataDog/integrations-tools-and-libraries
+*                       @DataDog/api-clients
 
 # Documentation
-*.md                    @DataDog/baklava @DataDog/integrations-tools-and-libraries
-LICENSE                 @DataDog/baklava @DataDog/integrations-tools-and-libraries
-LICENSE-3rdparty.csv    @DataDog/baklava @DataDog/integrations-tools-and-libraries
+*.md                    @DataDog/baklava @DataDog/api-clients
+LICENSE                 @DataDog/baklava @DataDog/api-clients
+LICENSE-3rdparty.csv    @DataDog/baklava @DataDog/api-clients


### PR DESCRIPTION
Cleanup from a team rename that already went into effect in Workday. The new team has the same members as the old one, plus managers:

https://github.com/orgs/DataDog/teams/integrations-tools-and-libraries
https://github.com/orgs/DataDog/teams/api-clients

Also updates `baklava` to the current team, `documentation`.

[APITL-857](https://datadoghq.atlassian.net/browse/APITL-857)

[APITL-857]: https://datadoghq.atlassian.net/browse/APITL-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ